### PR TITLE
Enable Khypervisor's proto2 on arndale board

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,23 @@ VExpress# cp.b 0x8200000 0xb0000000 0x100000; copy guest os#2 from flash@0x820_0
 VExpress# go 0xf000004c; this address is entry point of hypervisor
 </pre>
 
+Testing Hypervisor Prototype 2 for arndale
+==========================================
+1. configure SYSTEM variable in config-default.mk
+<pre>
+SYSTEM ?= arndale
+</pre>
+2. Build Hypervisor Prototype 2
+<pre>
+$ cd monitor
+$ make UBOOT=y
+</pre>
+3. Loading Image using Codevisor debugger 
+<pre>
+Bootloader will be supported.
+</pre>
+
+
 
 Tool chain
 =============

--- a/monitor/Makefile
+++ b/monitor/Makefile
@@ -21,24 +21,39 @@ endif
 
 LIBFDTOBJS      = libfdt/fdt.o libfdt/fdt_ro.o libfdt/fdt_wip.o \
 		  libfdt/fdt_sw.o libfdt/fdt_rw.o libfdt/fdt_strerror.o
+#BOOTLOADER	= boot.S
+#magicyaba
+ifeq ($(SYSTEM), arndale)
+BOOTLOADER	= ./boards/arndale/boot.S
+OBJS 		= ./boards/arndale/boot.o c_start.o string.o hmain.o \
+              monitor.o monitor_secure.o monitor_imp.o monitor_imp_secure.o \
+              ./boards/arndale/uart_print.o mm.o timer.o \
+              context.o gic.o interrupt.o smp.o scheduler.o generic_timer.o mct.o\
+			  vgic.o
+LD_SCRIPT	= ./boards/arndale/model.lds.S
+else # For VEXPRESS CA15
 BOOTLOADER	= boot.S
 OBJS 		= boot.o c_start.o string.o hmain.o \
               monitor.o monitor_secure.o monitor_imp.o monitor_imp_secure.o \
               uart_print.o mm.o timer.o \
-              context.o gic.o interrupt.o smp.o scheduler.o generic_timer.o \
+              context.o gic.o interrupt.o smp.o scheduler.o generic_timer.o mct.o\
               vgic.o
+LD_SCRIPT	= model.lds.S
+endif
+
+
 
 GUESTBIN	= bmguest.bin
 
 SEMIIMG 	= hvc-man-switch.axf
 MONITORMAP	= monitor.map
-LD_SCRIPT	= model.lds.S
+#end of magicyaba
 
 # Turn off BAREMETAL_GUEST flag to not embed bmguest.bin
 ifeq ($(UBOOT),y)
 CONFIG_FLAGS	= 
 else
-CONFIG_FLAGS	= -DBAREMETAL_GUEST -DBOARD_RTSMVE_CA15
+CONFIG_FLAGS	= -DBAREMETAL_GUEST 
 endif
 
 CPPFLAGS	+= $(CONFIG_FLAGS)

--- a/monitor/asm-arm_inline.h
+++ b/monitor/asm-arm_inline.h
@@ -1,1 +1,3 @@
 #define isb() asm volatile("isb" : : : "memory")
+#define dsb() asm volatile("dsb" : : : "memory")
+

--- a/monitor/boards/arndale/boot.S
+++ b/monitor/boards/arndale/boot.S
@@ -1,0 +1,196 @@
+/*
+ * boot.S - simple register setup code for stand-alone Linux booting
+ *
+ * Copyright (C) 2011 ARM Limited. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE.txt file.
+ */
+
+#define NS_BIT	0x1
+
+	.syntax	unified
+	.arch_extension sec
+	.arch_extension virt
+	.text
+
+.macro enter_hyp
+	@ We assume we're entered in Secure Supervisor mode. To
+	@ get to Hyp mode we have to pass through Monitor mode
+	@ and NS-Supervisor mode. Note that there is no way to
+	@ return to the Secure world once we've done this.
+	@
+	@ This will trash r10 and r11.
+	ldr	r10, =vectors
+	mcr	p15, 0, r10, c12, c0, 1		@ Monitor vector base address
+	@ Switch to monitor mode, which will set up the HVBAR and
+	@ then return to us in NS-SVC
+	smc	#0
+	@ Now we're in NS-SVC, make a Hyp call to get into Hyp mode
+	hvc	#0
+	@ We will end up here in NS-Hyp.
+.endm
+
+
+.align 5
+/* We use the same vector table for Hyp and Monitor mode, since
+ * we will only use each once and they don't overlap.
+ */
+vectors:
+	.word 0	/* reset */
+	.word 0	/* undef */
+	b	2f /* smc */
+	.word 0 /* pabt */
+	.word 0 /* dabt */
+	b	1f
+	.word 0 /* irq */
+	.word 0 /* fiq */
+
+/* Return directly back to the caller without leaving Hyp mode: */
+1:	mrs	lr, elr_hyp
+	mov	pc, lr
+
+/* In monitor mode, set up HVBAR and SCR then return to caller in NS-SVC. */
+2:
+	@ Set up HVBAR
+	mrc	p15, 0, r10, c1, c1, 0		@ SCR
+	@ Set SCR.NS=1 (needed for setting HVBAR and also returning to NS state)
+	@        .IRQ,FIQ,EA=0 (don't take aborts/exceptions to Monitor mode)
+	@        .FW,AW=1 (CPSR.A,F modifiable in NS state)
+	@        .nET=0 (early termination OK)
+	@        .SCD=1 (SMC in NS mode is UNDEF, so accidental SMCs don't
+	@                cause us to leap back into this code confusingly)
+	@        .HCE=1 (HVC does Hyp call)
+	bic	r10, r10, #0x07f
+	ldr	r11, =0x1b1
+	orr	r10, r10, r11
+	mcr	p15, 0, r11, c1, c1, 0
+	isb
+	ldr	r11, =vectors
+	mcr	p15, 4, r11, c12, c0, 0		@ set HVBAR
+	@ ...and return to calling code in NS state
+	movs	pc, lr
+
+	.globl	start
+start:
+#ifdef SMP
+#ifdef ARNDALE
+	@
+	@ Program architected timer frequency
+	@
+	mrc	p15, 0, r0, c0, c1, 1		@ CPUID_EXT_PFR1
+	lsr	r0, r0, #16
+	and	r0, r0, #1			        @ Check generic timer support
+	beq	1f
+
+    @ Current guess is CNTFRQ is fixed at 24MHz on Arndale board
+    @ - inkyu
+	ldr	r0, =24000000			    @ 24MHz timer frequency
+	mcr	p15, 0, r0, c14, c0, 0		@ CNTFRQ
+1:
+#endif
+	@
+	@ CPU initialisation
+	@
+	mrc	p15, 0, r4, c0, c0, 5		@ MPIDR (ARMv7 only)
+	and	r4, r4, #15			@ CPU number
+
+	@
+	@ Hypervisor / TrustZone initialization
+	@
+
+	@ Set all interrupts to be non-secure
+	@ldr	r0, =0x2c001000			@ Dist GIC base
+	ldr	r0, =0x10481000			@ Dist GIC base
+	ldr	r1, [r0, #0x04]			@ Type Register
+	cmp	r4, #0
+	andeq	r1, r1, #0x1f
+	movne	r1, #0
+	add	r2, r0, #0x080			@ Security Register 0
+	mvn	r3, #0
+2:	str	r3, [r2]
+	sub	r1, r1, #1
+	add	r2, r2, #4			@ Next security register
+	cmp	r1, #-1
+	bne	2b
+
+	@ Set GIC priority mask bit [7] = 1
+	@ldr	r0, =0x2c002000			@ CPU GIC base
+	ldr	r0, =0x10482000			@ CPU GIC base
+	mov	r1, #0x80
+	str	r1, [r0, #0x4]			@ GIC ICCPMR
+
+	@ Set NSACR to allow coprocessor access from non-secure
+	mrc	p15, 0, r0, c1, c1, 2
+	ldr	r1, =0x43fff
+	orr	r0, r0, r1
+	mcr	p15, 0, r0, c1, c1, 2
+
+	@ Check CPU nr again
+	mrc	p15, 0, r0, c0, c0, 5		@ MPIDR (ARMv7 only)
+	bfc	r0, #24, #8			@ CPU number, taking multicluster into account
+	cmp	r0, #0				@ primary CPU?
+	beq	2f
+
+	@
+	@ Secondary CPUs (following the RealView SMP booting protocol)
+	@
+	enter_hyp
+
+	ldr	r1, =fs_start - 0x100
+	adr	r2, 1f
+	ldmia	r2, {r3 - r7}			@ move the code to a location
+	stmia	r1, {r3 - r7}			@ less likely to be overridden
+	mov	pc, r1				@ branch to the relocated code
+1:
+#ifdef ARNDALE
+	wfe
+#endif
+	ldr	r1, [r0]
+	cmp	r1, #0
+	beq	1b
+	mov	pc, r1				@ branch to the given address
+#endif
+
+2:
+	@
+	@ UART initialisation (38400 8N1)
+	@
+#ifdef MACH_MPS
+	ldr	r0, =0x1f005000			@ UART3 base (MPS)
+#elif defined (ARNDALE)
+	ldr	r0, =0x12c00000			@ UART base (ARNDALE)
+#else
+	ldr	r0, =0x10009000			@ UART base (RealView/EB)
+#endif
+	@mov	r1, #0x10			@ ibrd
+	@str	r1, [r0, #0x24]
+	@mov	r1, #0xc300
+	@orr	r1, #0x0001			@ cr
+	@str	r1, [r0, #0x30]
+
+	@ Now we've got rid of the secondary CPUs, set up a stack
+	@ for CPU 0 so we can write most of this in C.
+	ldr     sp, =sec_stacklimit
+
+	@ And call the C entrypoint
+	bl      c_start
+	@ Never reached
+1:	b 1b
+
+	@
+	@ Function for C code to make semihosting calls:
+	@
+	.globl __semi_call
+__semi_call:
+#if defined(MACH_MPS)
+	@ M profile semihosting is via bpkt
+	bkpt    0xab
+#elif defined(__thumb__)
+	@ Otherwise, different SVC numbers for ARM or Thumb mode
+	svc    0xab
+#else
+	svc     0x123456
+#endif
+	mov pc, lr
+

--- a/monitor/boards/arndale/exynos-uart.h
+++ b/monitor/boards/arndale/exynos-uart.h
@@ -1,0 +1,59 @@
+/*
+ * (C) Copyright 2009 Samsung Electronics
+ * Minkyu Kang <mk7.kang@samsung.com>
+ * Heungjun Kim <riverful.kim@samsung.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+ * MA 02111-1307 USA
+ *
+ */
+
+#ifndef __ASM_ARCH_UART_H_
+#define __ASM_ARCH_UART_H_
+
+#ifndef __ASSEMBLY__
+/* baudrate rest value */
+union br_rest {
+	unsigned short	slot;		/* udivslot */
+	unsigned char	value;		/* ufracval */
+};
+
+struct s5p_uart {
+	unsigned int	ulcon;
+	unsigned int	ucon;
+	unsigned int	ufcon;
+	unsigned int	umcon;
+	unsigned int	utrstat;
+	unsigned int	uerstat;
+	unsigned int	ufstat;
+	unsigned int	umstat;
+	unsigned char	utxh;
+	unsigned char	res1[3];
+	unsigned char	urxh;
+	unsigned char	res2[3];
+	unsigned int	ubrdiv;
+	union br_rest	rest;
+	unsigned char	res3[0xffd0];
+};
+
+static inline int s5p_uart_divslot(void)
+{
+	return 0;
+}
+
+#endif	/* __ASSEMBLY__ */
+
+#endif
+

--- a/monitor/boards/arndale/model.lds.S
+++ b/monitor/boards/arndale/model.lds.S
@@ -1,0 +1,124 @@
+/*
+ * model.lds.S - simple linker script for stand-alone Linux booting
+ *
+ * Copyright (C) 2011 ARM Limited. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE.txt file.
+ */
+OUTPUT_FORMAT("elf32-littlearm")
+OUTPUT_ARCH(arm)
+TARGET(binary)
+ENTRY(start)
+
+#ifndef SEMIHOSTING
+INPUT(./uImage)
+#ifdef USE_INITRD
+ INPUT(./filesystem.cpio.gz)
+#endif
+#endif
+
+#ifdef BAREMETAL_GUEST
+	INPUT(./bmguest.bin)
+/* INPUT(./bmguest2.bin) */
+#endif
+
+/* 
+ * Change stack offset for arndale board
+ * - magicyaba
+ */
+
+PHYS_OFFSET = 0x40000000;       /* Customize */
+MON_OFFSET  = 0xa0000000;       /* Customize */
+
+MON_SIZE    = 0x0F000000;
+MON_STACK	= MON_OFFSET + MON_SIZE;
+MON_STACK_SIZE  = 0x00c00000;
+
+SEC_STACKTOP = MON_STACK + MON_STACK_SIZE;
+SEC_STACK_SIZE  = 0x00400000;
+
+/* NS.SVC mode code space 
+ * - simon
+ * Change code space for arndale board
+ * - magicyaba
+ */
+GUEST_OFFSET  	= 0x60000000;   /* Customize */
+GUEST_SIZE_MAX	= 0x0F000000;
+GUEST_STACK  	= GUEST_OFFSET + GUEST_SIZE_MAX;
+
+GUEST2_OFFSET	= 0x70000000;   /* Customize */
+GUEST2_STACK	= GUEST2_OFFSET + GUEST_SIZE_MAX;
+
+
+SECTIONS
+{
+ . = PHYS_OFFSET;
+ . = PHYS_OFFSET + 0x8000 - 0x40;
+ . = PHYS_OFFSET + 0x00d00000;
+
+ fs_start = .;
+#if defined(USE_INITRD) && !defined(SEMIHOSTING)
+ .filesystem : { ./filesystem.cpio.gz }
+#endif
+ fs_end = .;
+
+/* Guest 1 */
+ . = GUEST_OFFSET;
+  guest_bin_start = .; 
+#ifdef BAREMETAL_GUEST
+  .guest : { ./bmguest.bin }
+#else
+	/* dummy space for guest */
+ . = GUEST_OFFSET + GUEST_SIZE_MAX;
+#endif
+  guest_bin_end = .; 
+
+ . = GUEST_STACK;
+ guest_stacktop = .;
+ . = GUEST_STACK + 0x01000000; 
+ guest_stacklimit = .;
+
+/* Guest 2 */
+ . = GUEST2_OFFSET;
+  guest2_bin_start = .; 
+#ifdef BAREMETAL_GUEST
+  .guest2 : { ./bmguest.bin }
+#else
+	/* dummy space for guest */
+ . = GUEST2_OFFSET + GUEST_SIZE_MAX; 
+#endif
+  guest2_bin_end = .; 
+
+
+ . = GUEST2_STACK;
+ guest2_stacktop = .;
+ . = GUEST2_STACK + 0x01000000; 
+ guest2_stacklimit = .;
+
+ . = MON_OFFSET;
+ /* Put most of the actual boot loader code up in high memory
+  * where it won't get overwritten by kernel, initrd or atags.
+  */
+ .text : { 
+	./boards/arndale/boot.o(.text) 
+	monitor.o(.text) 
+ }
+ .data : { 
+	./boards/arndale/boot.o(.data) 
+	monitor.o(.data) 
+ }
+ .bss : { 
+	./boards/arndale/boot.o(.bss) 
+	monitor.o(.bss) 
+ }
+ . = MON_STACK;
+ mon_stacktop = .;
+ . = MON_STACK + MON_STACK_SIZE;
+ mon_stacklimit = .;
+
+ . = SEC_STACKTOP;
+ sec_stacktop = .;
+ . = SEC_STACKTOP + SEC_STACK_SIZE;
+ sec_stacklimit = .;
+}

--- a/monitor/boards/arndale/uart_print.c
+++ b/monitor/boards/arndale/uart_print.c
@@ -1,0 +1,95 @@
+#include "arch_types.h"
+#include "exynos-uart.h"
+
+#ifdef MACH_MPS
+#define UART_BASE       0x1f005000
+#elif defined (ARNDALE)
+#define UART0       	0x12c20000
+#define UTXH		0x20
+#define UFSTAT		0x18
+#define UART_BASE 	(UART0 + UTXH)
+#else
+#define UART_BASE       0x10009000
+#endif
+
+#if 0
+void uart_print(const char *str)
+{
+        volatile char *pUART = (char *) UART_BASE;
+        while(*str) {
+                *pUART = *str++;
+        }
+}
+
+void uart_putc( const char c )
+{
+        volatile char *pUART = (char *) UART_BASE;
+	*pUART = c;
+}
+#endif
+
+#define TX_FIFO_FULL_MASK       (1 << 24)
+#define	readl(a)		 (*(volatile unsigned int *)(a))
+#define	writeb(v, a)		 (*(volatile unsigned char *)(a) = (v))
+
+static int serial_err_check(int op)
+{
+	struct s5p_uart *const uart = (struct s5p_uart *) UART0;
+	unsigned int mask;
+
+	if(op)
+		mask = 0x8;
+	else
+		mask = 0xf;
+
+	return readl(&uart->uerstat) & mask;
+
+}
+
+void uart_putc(const char c)
+{
+	struct s5p_uart *const uart = (struct s5p_uart *) UART0;
+
+
+	while((readl(&uart->ufstat) & TX_FIFO_FULL_MASK)) {
+		if (serial_err_check(1))
+			return;
+	}
+
+	writeb(c, &uart->utxh);
+
+	if(c == '\n')
+		uart_putc('\r');
+	
+
+}
+void uart_print(const char *str)
+{
+	while(*str) {
+		uart_putc(*str++);
+	}
+}
+
+void uart_print_hex32( uint32_t v )
+{
+	unsigned int mask8 = 0xF;
+	unsigned int c;
+	int i;
+	uart_print("0x");
+	
+	for ( i = 7; i >= 0; i-- ) {
+		c = (( v >> (i * 4) ) & mask8);
+		if ( c < 10 ) {
+			c += '0';
+		} else {
+			c += 'A' - 10;
+		}
+		uart_putc( (char) c );
+	}
+}
+
+void uart_print_hex64( uint64_t v )
+{
+	uart_print_hex32( v >> 32 );
+	uart_print_hex32( (uint32_t) (v & 0xFFFFFFFF) );
+}

--- a/monitor/boards/arndale/uart_print.h
+++ b/monitor/boards/arndale/uart_print.h
@@ -1,0 +1,13 @@
+#ifndef __UART_PRINT_H__
+#define __UART_PRINT_H__
+#include "arch_types.h"
+
+#define HVMM_TRACE_ENTER()	{uart_print( __FUNCTION__ );  uart_print("() - enter\n\r");}
+#define HVMM_TRACE_EXIT()	{uart_print( __FUNCTION__ );  uart_print("() - exit\n\r");}
+
+void uart_putc( const char c );
+void uart_print(const char *str);
+void uart_print_hex32( uint32_t v );
+void uart_print_hex64( uint64_t v );
+
+#endif

--- a/monitor/config-default.mk
+++ b/monitor/config-default.mk
@@ -22,6 +22,7 @@ KERNEL_SRC	?= ../linux-kvm-arm
 # mps:		MPS (Cortex-M3)
 # realview_eb:	RealViewPB, EB, etc.
 # vexpress:	Versatile Express
+# arndale:	arndale board
 SYSTEM ?= vexpress
 
 ###########################################################################
@@ -79,6 +80,16 @@ endif
 endif # SYSTEM = realvire_eb
 
 
+###########################################################################
+# Versatile Express
+#
+ifeq ($(SYSTEM),arndale)
+
+CPPFLAGS	+= -DSMP
+CPPFLAGS	+= -mcpu=cortex-a15 -marm
+CPPFLAGS	+= -DARNDALE -g
+
+endif
 ###########################################################################
 # Versatile Express
 #

--- a/monitor/config-default.mk
+++ b/monitor/config-default.mk
@@ -22,7 +22,9 @@ KERNEL_SRC	?= ../linux-kvm-arm
 # mps:		MPS (Cortex-M3)
 # realview_eb:	RealViewPB, EB, etc.
 # vexpress:	Versatile Express
-SYSTEM ?= vexpress
+# arndale:	arndale board
+#SYSTEM ?= vexpress
+SYSTEM ?= arndale
 
 ###########################################################################
 # Turn this on to use an initrd whose contents are in filesystem.cpio.gz
@@ -79,6 +81,16 @@ endif
 endif # SYSTEM = realvire_eb
 
 
+###########################################################################
+# Versatile Express
+#
+ifeq ($(SYSTEM),arndale)
+
+CPPFLAGS	+= -DSMP
+CPPFLAGS	+= -mcpu=cortex-a15 -marm
+CPPFLAGS	+= -DARNDALE -g
+
+endif
 ###########################################################################
 # Versatile Express
 #

--- a/monitor/generic_timer.c
+++ b/monitor/generic_timer.c
@@ -1,5 +1,8 @@
 #include "generic_timer.h"
 #include "hvmm_trace.h"
+#if defined(ARNDALE)
+    #include "mct.h"
+#endif
 
 static void _generic_timer_hyp_irq_handler(int irq, void *regs, void *pdata);
 
@@ -9,6 +12,9 @@ static generic_timer_callback_t _callback[GENERIC_TIMER_NUM_TYPES];
 
 hvmm_status_t generic_timer_init()
 {
+    #if defined(ARNDALE)
+        mct_init(); 
+    #endif
     _timer_irqs[GENERIC_TIMER_HYP] = 26;
     _timer_irqs[GENERIC_TIMER_NSP] = 27;
     _timer_irqs[GENERIC_TIMER_VIR] = 30;

--- a/monitor/gic.c
+++ b/monitor/gic.c
@@ -23,6 +23,12 @@
 
 #define GIC_SIGNATURE_INITIALIZED   0x5108EAD7
 
+#if defined(ARNDALE)
+    #define GIC_BASEADDR    0x10480000 
+#else
+    #define GIC_BASEADDR    0
+#endif
+
 struct gic {
 	uint32_t baseaddr;
 	volatile uint32_t *ba_gicd;
@@ -247,7 +253,7 @@ hvmm_status_t gic_init(void)
 	/*
 	 * Determining VA of GIC base adddress has not been defined yet. Let is use the PA for the time being
 	 */
-	result = gic_init_baseaddr(0);
+    result = gic_init_baseaddr((void*)GIC_BASEADDR);
 
 	if ( result == HVMM_STATUS_SUCCESS ) {
 		gic_dump_registers();

--- a/monitor/io.h
+++ b/monitor/io.h
@@ -1,0 +1,22 @@
+#ifndef __IO_H__
+#define __IO_H_
+/*
+ * For write data on physical address.
+ */
+#include "arch_types.h"
+#include "asm-arm_inline.h"
+#define __raw_write32(a, v) (*(volatile uint32_t *)(a) = (v))
+#define __raw_read32(a)     (*(volatile uint32_t *)(a))
+#define __iowmb()   dsb()
+#define __iormb()   dsb()
+#define arch_out_le32(a, v) {__iowmb(); __raw_write32(a, v); }
+#define arch_in_le32(a)     ({uint32_t v = __raw_read32(a); __iormb(); v; })
+static inline uint32_t vmm_readl(volatile void *addr)
+{     
+     return arch_in_le32(addr);
+} 
+static inline void vmm_writel(uint32_t data, volatile void *addr)
+{
+     arch_out_le32(addr, data);
+}
+#endif

--- a/monitor/mct.c
+++ b/monitor/mct.c
@@ -1,0 +1,82 @@
+#include "mct.h"
+#define likely(x)   __builtin_expect(!!(x), 1)
+static void *exynos5_sys_timer;
+static inline uint32_t exynos5_mct_read(uint32_t offset)
+{
+    return vmm_readl((void *) EXYNOS5_MCT_BASE + offset);
+}
+static void exynos5_mct_write(uint32_t value, uint32_t offset){
+
+    uint32_t stat_addr;
+    uint32_t mask;
+    uint32_t i;
+    exynos5_sys_timer = (void *)EXYNOS5_MCT_BASE;
+
+    vmm_writel(value, exynos5_sys_timer + offset);
+
+    if(likely(offset >= EXYNOS5_MCT_L_BASE(0))){
+        uint32_t base = offset & EXYNOS5_MCT_L_MASK;
+        switch( offset & ~EXYNOS5_MCT_L_MASK){
+            case (uint32_t) MCT_L_TCON_OFFSET:
+                stat_addr = base + MCT_L_WSTAT_OFFSET;
+                mask = 1 << 3;
+                break;
+            case (uint32_t) MCT_L_ICNTB_OFFSET:
+                stat_addr = base + MCT_L_WSTAT_OFFSET;
+                mask = 1 << 1;  /* L_ICNTB write status */
+                break;
+            case (uint32_t) MCT_L_TCNTB_OFFSET:
+                stat_addr = base + MCT_L_WSTAT_OFFSET;
+                mask = 1 << 0;  /* L_TCNTB write status */
+                break;
+            default:
+                return;
+        }
+    }else{
+        switch (offset) {
+            case (uint32_t) EXYNOS5_MCT_G_TCON:
+                stat_addr = EXYNOS5_MCT_G_WSTAT;
+                mask = 1 << 16; /* G_TCON write status */
+                break;
+            case (uint32_t) EXYNOS5_MCT_G_COMP0_L:
+                stat_addr = EXYNOS5_MCT_G_WSTAT;
+                mask = 1 << 0;  /* G_COMP0_L write status */
+                break;
+            case (uint32_t) EXYNOS5_MCT_G_COMP0_U:
+                stat_addr = EXYNOS5_MCT_G_WSTAT;
+                mask = 1 << 1;  /* G_COMP0_U write status */
+                break;
+            case (uint32_t) EXYNOS5_MCT_G_COMP0_ADD_INCR:
+                stat_addr = EXYNOS5_MCT_G_WSTAT;
+                mask = 1 << 2;  /* G_COMP0_ADD_INCR w status */
+                break;
+            case (uint32_t) EXYNOS5_MCT_G_CNT_L:
+                stat_addr = EXYNOS5_MCT_G_CNT_WSTAT;
+                mask = 1 << 0;  /* G_CNT_L write status */
+                break;
+            case (uint32_t) EXYNOS5_MCT_G_CNT_U:
+                stat_addr = EXYNOS5_MCT_G_CNT_WSTAT;
+                mask = 1 << 1;  /* G_CNT_U write status */
+                break;
+            default:
+                return;
+        }
+    }
+    /* Wait maximum 1 ms until written values are applied */
+    for (i = 0; i < 0x1000; i++) {
+        /* So we do this loop up to 1000 times */
+        if (exynos5_mct_read(stat_addr) & mask) {
+            vmm_writel(mask, exynos5_sys_timer + stat_addr);
+            return;
+        }
+    }
+}
+
+void mct_init(void){
+    uint32_t reg;
+    exynos5_mct_write(0, EXYNOS5_MCT_G_CNT_L);
+    exynos5_mct_write(0, EXYNOS5_MCT_G_CNT_U);
+    reg = exynos5_mct_read(EXYNOS5_MCT_G_TCON);
+    reg |= MCT_G_TCON_START;
+    exynos5_mct_write(reg, EXYNOS5_MCT_G_TCON);
+}

--- a/monitor/mct.h
+++ b/monitor/mct.h
@@ -1,0 +1,28 @@
+#ifndef __MCT_H__
+#define __MCT_H__
+/*
+ * To operate Generic timer's system counter register on Arndale board, call mct_init function.
+ */
+#include "io.h"
+#define EXYNOS5_MCT_BASE 0x101C0000
+#define EXYNOS5_MCTREG(x)       (x)
+#define EXYNOS5_MCT_L_MASK (0xffffff00)
+#define MCT_L_TCON_OFFSET   (0x20)
+#define MCT_L_WSTAT_OFFSET  (0x40)
+#define MCT_L_ICNTB_OFFSET  (0x08)
+#define EXYNOS5_MCT_G_TCON      EXYNOS5_MCTREG(0x240)
+#define EXYNOS5_MCT_G_WSTAT     EXYNOS5_MCTREG(0x24C)
+#define EXYNOS5_MCT_G_COMP0_L       EXYNOS5_MCTREG(0x200)
+#define EXYNOS5_MCT_G_COMP0_U       EXYNOS5_MCTREG(0x204)
+#define EXYNOS5_MCT_G_COMP0_ADD_INCR    EXYNOS5_MCTREG(0x208)
+#define EXYNOS5_MCT_G_CNT_L     EXYNOS5_MCTREG(0x100)
+#define EXYNOS5_MCT_G_CNT_U     EXYNOS5_MCTREG(0x104)
+#define MCT_L_TCNTB_OFFSET      (0x00)
+#define EXYNOS5_MCT_G_CNT_WSTAT     EXYNOS5_MCTREG(0x110)
+#define MCT_G_TCON_START    (1 << 8)
+#define _EXYNOS5_MCT_L_BASE     EXYNOS5_MCTREG(0x300)
+#define EXYNOS5_MCT_L_BASE(x)   (_EXYNOS5_MCT_L_BASE + (0x100 + x))
+
+void mct_init(void);
+
+#endif

--- a/monitor/timer.h
+++ b/monitor/timer.h
@@ -4,7 +4,11 @@
 #include "hvmm_types.h"
 #include "arch_types.h"
 
-#if defined(BOARD_RTSMVE_CA15)
+#if defined(VEXPRESS)
+    #define COUNT_PER_USEC 100
+#elif defined(ARNDALE)
+    #define COUNT_PER_USEC 24
+#else
     #define COUNT_PER_USEC 100
 #endif
 


### PR DESCRIPTION
1. Add board directory for arndale board.
2. Add Mct.c for enable Generic Timer. 
3. Delete BOARD_RTSMVE_CA15 predefine. Because already use VEXPRESS, ARNDALE predefine in boot.S. 
   So use VEXPRESS predefine instead of BOARD_RTSMVE_CA15.
