### PR TITLE
Vgic

### DIFF
--- a/monitor/context.h
+++ b/monitor/context.h
@@ -4,6 +4,7 @@
 #include "hyp_config.h"
 #include "arch_types.h"
 #include "mm.h"
+#include "vgic.h"
 
 #define NUM_GUEST_CONTEXTS		NUM_GUESTS_STATIC
 #define ARCH_REGS_NUM_GPR	13
@@ -23,6 +24,7 @@ struct hyp_guest_context {
         struct arch_regs regs;
         lpaed_t *ttbl;
         vmid_t vmid;
+        struct vgic_status vgic_status;
 };
 
 void context_dump_regs( struct arch_regs *regs );

--- a/monitor/vgic.h
+++ b/monitor/vgic.h
@@ -11,8 +11,18 @@ typedef enum {
     VIRQ_STATE_PENDING_ACTIVE = 0x03,
 } virq_state_t;
 
+struct vgic_status {
+    uint32_t saved_once;    /* restore only if saved once to avoid dealing with corrupted data */
+    uint32_t lr[64];
+    uint32_t hcr;
+    uint32_t apr;
+    uint32_t vmcr;
+};
+
 hvmm_status_t vgic_enable(uint8_t enable);
 hvmm_status_t vgic_init(void);
+hvmm_status_t vgic_save_status( struct vgic_status *status );
+hvmm_status_t vgic_restore_status( struct vgic_status *status );
 hvmm_status_t vgic_inject_virq_sw( uint32_t virq, virq_state_t state, uint32_t priority, 
                                     uint32_t cpuid, uint8_t maintenance);
 hvmm_status_t vgic_inject_virq_hw( uint32_t virq, virq_state_t state, uint32_t priority, uint32_t pirq);


### PR DESCRIPTION
VGIC: 
- guest context switch now saves/restores VGIC configuration. 
- test code in tests_gic_timer.c injects virq 30 every timer_sched tick to the current guest only for test purpose
