### PR TITLE
context now flushes queued virqs to the current guest 

### DIFF
--- a/bmguest/c_start.c
+++ b/bmguest/c_start.c
@@ -63,8 +63,13 @@ void nrm_loop(void)
 
     irq_enable();
 
-    /* Test the sample virtual device */
+    /* Test the sample virtual device 
+     * - Uncomment the following line of code only if 'vdev_sample' is registered at the monitor
+     * - Otherwise, the monitor will hang with data abort
+     */
+    /* 
     test_vdev_sample();
+    */
 
 	for( i = 0; i < NUM_ITERATIONS; i++ ) {
 		nrm_delay();

--- a/bmguest/gic.c
+++ b/bmguest/gic.c
@@ -191,35 +191,28 @@ void gic_interrupt(int fiq, void *pregs)
     uint32_t iar;
     uint32_t irq;
     struct arch_regs *regs = pregs;
-    uint8_t did_isr = 0;
 
-
-    uart_print( "ba_gicc:"); uart_print_hex32((uint32_t)_gic.ba_gicc); uart_print("\n\r");
-    do {
-        /* ACK */
-        iar = _gic.ba_gicc[GICC_IAR];
-        irq = iar & GICC_IAR_INTID_MASK;
-        if ( irq < _gic.lines ) {
-            uart_print( "irq:"); uart_print_hex32(irq); uart_print("\n\r");
-            if ( irq == 0 ) {
-                uart_print( "ba_gicd:"); uart_print_hex32((uint32_t) _gic.ba_gicd); uart_print("\n\r");
-                uart_print( "ba_gicc:"); uart_print_hex32((uint32_t) _gic.ba_gicc); uart_print("\n\r");
-            }
-
-            /* ISR */
-            if ( _gic.handlers[irq] ) {
-                _gic.handlers[irq]( irq, regs, 0 );
-            }
-
-            /* Completion & Deactivation */
-            _gic.ba_gicc[GICC_EOIR] = irq;
-            _gic.ba_gicc[GICC_DIR] = irq;
-            did_isr = 1;
-        } else {
-            if ( did_isr ) {
-                uart_print( "end of irq(no pending):"); uart_print_hex32(irq); uart_print("\n\r");
-            }
-            break;
+    /* ACK */
+    iar = _gic.ba_gicc[GICC_IAR];
+    irq = iar & GICC_IAR_INTID_MASK;
+    if ( irq < _gic.lines ) {
+        uart_print( "irq:"); uart_print_hex32(irq); uart_print("\n\r");
+        if ( irq == 0 ) {
+            uart_print( "ba_gicd:"); uart_print_hex32((uint32_t) _gic.ba_gicd); uart_print("\n\r");
+            uart_print( "ba_gicc:"); uart_print_hex32((uint32_t) _gic.ba_gicc); uart_print("\n\r");
         }
-    } while(1);
+
+        /* ISR */
+        if ( _gic.handlers[irq] ) {
+            _gic.handlers[irq]( irq, regs, 0 );
+        }
+
+        /* Completion & Deactivation */
+        _gic.ba_gicc[GICC_EOIR] = irq;
+        _gic.ba_gicc[GICC_DIR] = irq;
+    } else {
+        if ( did_isr ) {
+            uart_print( "end of irq(no pending):"); uart_print_hex32(irq); uart_print("\n\r");
+        }
+    }
 }

--- a/bmguest/guest.S
+++ b/bmguest/guest.S
@@ -77,7 +77,7 @@ except_unhandled:
 	@ Pop registers
 	pop 	{r0,lr}             /* CPSR, LR */
 	msr	    spsr, r0
-	ldm	    sp, {r0-r12}
+	pop 	{r0-r12}
 	movs	pc, lr
 
 except_svc:
@@ -92,7 +92,7 @@ except_svc:
 	@ Pop registers
 	pop 	{r0,lr}             /* CPSR, LR */
 	msr	    spsr, r0
-	ldm	    sp, {r0-r12}
+	pop	    {r0-r12}
 	movs	pc, lr
 
 except_irq:
@@ -107,7 +107,7 @@ except_irq:
 	@ Pop registers
 	pop 	{r0,lr}             /* CPSR, LR */
 	msr	    spsr, r0
-	ldm	    sp, {r0-r12}
+	pop	    {r0-r12}
 
     @ movs	pc, lr
     subs    pc, lr, #4

--- a/bmguest/test_vdev_sample.c
+++ b/bmguest/test_vdev_sample.c
@@ -16,18 +16,22 @@ void test_vdev_sample()
     int i;
     int v1, v2, r;
 
+    uart_print( "vdev_sample: Starting test..., base:" ); uart_print_hex32( base ); uart_print("\n\r");
     for( i = 0; i < 10; i++ ) {
         v1 = ( 1 + i ) * 2;
         v2 = ( 1 + i ) * 3;
-        *reg_a = v1;
-        *reg_b = v2;
-        r = *reg_c;
 
         uart_print("v1(" ); 
         uart_print_hex32( v1 );
         uart_print(")+v2(" ); 
         uart_print_hex32( v2 );
-        uart_print(")=r(" ); 
+        uart_print(")\n\r" ); 
+
+        *reg_a = v1;
+        *reg_b = v2;
+        r = *reg_c;
+
+        uart_print("    = r(" ); 
         uart_print_hex32( r );
 
         if ( r == ( v1 + v2 ) ) {
@@ -37,4 +41,5 @@ void test_vdev_sample()
         }
         uart_print("\n\r" ); 
     }
+    uart_print( "vdev_sample: End\n\r" );
 }

--- a/monitor/context.c
+++ b/monitor/context.c
@@ -366,6 +366,9 @@ hvmm_status_t context_perform_switch(void)
             result = context_perform_switch_to_guest_regs( regs, _next_guest_vmid );
             _next_guest_vmid = VMID_INVALID;
         }
+    } else {
+        /* Staying at the currently active guest. Flush out queued virqs since we didn't have a chance to switch the context, where virq flush takes place,  this time */
+        vgic_flush_virqs(_current_guest_vmid);
     }
 
     _switch_locked = 0;

--- a/monitor/devices/gic/vgic.c
+++ b/monitor/devices/gic/vgic.c
@@ -215,7 +215,12 @@ static void _vgic_isr_maintenance_irq(int irq, void *pregs, void *pdata)
         }
     }
 
-    vgic_injection_enable(0);
+    if ( _vgic.base[GICH_MISR] & GICH_MISR_NP ) {
+        /* No pending virqs, no need to keep vgic enabled */
+        vgic_enable(0);
+        vgic_injection_enable(0);
+    }
+
 
     HVMM_TRACE_EXIT();
 }
@@ -229,12 +234,11 @@ hvmm_status_t vgic_enable(uint8_t enable)
         if ( enable ) {
             uint32_t hcr = _vgic.base[GICH_HCR];
 
-            hcr |= GICH_HCR_EN;
-            // hcr |= GICH_HCR_NPIE | GICH_HCR_LRENPIE;
+            hcr |= GICH_HCR_EN | GICH_HCR_NPIE;
 
             _vgic.base[GICH_HCR] = hcr;
         } else {
-            _vgic.base[GICH_HCR] &= ~(GICH_HCR_EN);
+            _vgic.base[GICH_HCR] &= ~(GICH_HCR_EN | GICH_HCR_NPIE);
         }
 
         result = HVMM_STATUS_SUCCESS;
@@ -306,6 +310,7 @@ hvmm_status_t vgic_inject_virq(
     if ( slot != VGIC_SLOT_NOTFOUND ) {
         _vgic.base[GICH_LR + slot] = lr_desc;
         vgic_injection_enable(1);
+        vgic_enable(1);
         result = HVMM_STATUS_SUCCESS;
     }
     _vgic_dump_regs();
@@ -467,8 +472,6 @@ hvmm_status_t vgic_restore_status( struct vgic_status *status, vmid_t vmid )
     _vgic_dump_regs();
     result = HVMM_STATUS_SUCCESS;
 
-    vgic_enable(1);
-    
     return result;
 }
 

--- a/monitor/devices/gic/vgic.c
+++ b/monitor/devices/gic/vgic.c
@@ -461,14 +461,24 @@ hvmm_status_t vgic_restore_status( struct vgic_status *status, vmid_t vmid )
     _vgic.base[GICH_HCR] = status->hcr;
 
     /* Inject queued virqs to the next guest */
-    if ( _cb_virq_flush != 0 )
-        _cb_virq_flush(vmid);
+    vgic_flush_virqs(vmid);
 
     _vgic_dump_regs();
     result = HVMM_STATUS_SUCCESS;
 
     vgic_enable(1);
     
+    return result;
+}
+
+hvmm_status_t vgic_flush_virqs(vmid_t vmid)
+{
+    hvmm_status_t result = HVMM_STATUS_IGNORED;
+    if ( _cb_virq_flush != 0 ) {
+        _cb_virq_flush(vmid);
+        result = HVMM_STATUS_SUCCESS;
+    }
+
     return result;
 }
 

--- a/monitor/include/gic_regs.h
+++ b/monitor/include/gic_regs.h
@@ -88,4 +88,6 @@
 #define GICH_LR_HW            (0x1 << GICH_LR_HW_SHIFT)
 
 #define GICH_MISR_EOI           (1)
+#define GICH_MISR_NP_SHIFT      (3)
+#define GICH_MISR_NP            (1 << GICH_MISR_NP_SHIFT)
 #endif

--- a/monitor/include/vgic.h
+++ b/monitor/include/vgic.h
@@ -24,6 +24,7 @@ hvmm_status_t vgic_init(void);
 hvmm_status_t vgic_init_status( struct vgic_status *status, vmid_t vmid );
 hvmm_status_t vgic_save_status( struct vgic_status *status, vmid_t vmid );
 hvmm_status_t vgic_restore_status( struct vgic_status *status, vmid_t vmid );
+hvmm_status_t vgic_flush_virqs(vmid_t vmid);
 hvmm_status_t vgic_inject_virq_sw( uint32_t virq, virq_state_t state, uint32_t priority, 
                                     uint32_t cpuid, uint8_t maintenance);
 hvmm_status_t vgic_inject_virq_hw( uint32_t virq, virq_state_t state, uint32_t priority, uint32_t pirq);

--- a/monitor/monitor.S
+++ b/monitor/monitor.S
@@ -47,7 +47,7 @@ trap_hvc:
 	pop 	{r0-r1}
 	msr	    spsr_hyp, r0
 	msr	    elr_hyp, r1
-	ldm	    sp, {r0-r12}
+	pop     {r0-r12}
 
 	@ else if return == HYP_RET_ERET -> Exception Return
 	eret
@@ -58,7 +58,7 @@ trap_hvc:
 	tst 	r0, #0x1f
 	msrne	spsr_hyp, r0
 	msr	elr_hyp, r1
-	ldm	sp, {r0-r12}
+	pop     {r0-r12}
 	@ stay in Hyp mode
 	mrs	lr, elr_hyp
 	mov	pc, lr
@@ -82,7 +82,7 @@ trap_dabt:
 	pop 	{r0-r1}
 	msr	spsr_hyp, r0
 	msr	elr_hyp, r1
-	ldm	sp, {r0-r12}
+	pop     {r0-r12}
 	eret
 
 trap_irq:
@@ -100,7 +100,7 @@ trap_irq:
 	pop 	{r0-r1}
 	msr	    spsr_hyp, r0
 	msr	    elr_hyp, r1
-	ldm	    sp, {r0-r12}
+	pop     {r0-r12}
 	eret
 
 trap_unhandled:
@@ -118,7 +118,7 @@ trap_unhandled:
 	pop 	{r0-r1}
 	msr     spsr_hyp, r0
 	msr     elr_hyp, r1
-	ldm     sp, {r0-r12}
+	pop     {r0-r12}
 	eret
 
 .global __mon_switch_to_guest_context

--- a/monitor/monitor_secure.S
+++ b/monitor/monitor_secure.S
@@ -63,7 +63,7 @@ trap_secure_unhandled:
 	@ Pop registers
 	pop 	{r0-r1}
 	msr	spsr_mon, r0
-	ldm	sp, {r0-r12}
+	pop     {r0-r12}
 	eret
 
 /* 

--- a/monitor/trap_dabort.h
+++ b/monitor/trap_dabort.h
@@ -1,6 +1,7 @@
 #ifndef __TRAP_DABORT_H__
 #define __TRAP_DABORT_H__
+#include <hvmm_types.h>
 
-void trap_hvc_dabort(unsigned int iss, struct arch_regs *regs);
+hvmm_status_t trap_hvc_dabort(unsigned int iss, struct arch_regs *regs);
 
 #endif

--- a/monitor/virq.c
+++ b/monitor/virq.c
@@ -51,7 +51,6 @@ static void virq_flush(vmid_t vmid)
     int count = 0;
     struct virq_entry *entries = &_guest_virqs[vmid][0];
 
-    HVMM_TRACE_ENTER();
     for( i = 0; i < VIRQ_MAX_ENTRIES; i++) {
         if ( entries[i].valid ) {
             hvmm_status_t result;
@@ -71,8 +70,9 @@ static void virq_flush(vmid_t vmid)
             count++;
         }
     }
-    printh( "virq: injected %d virqs to vmid %d \n", count, vmid );
-    HVMM_TRACE_EXIT();
+    if ( count > 0 ) {
+        printh( "virq: injected %d virqs to vmid %d \n", count, vmid );
+    }
 }
 
 hvmm_status_t virq_init(void)


### PR DESCRIPTION
when no guest switching occurs (i.e. single guest configuration). 
- vgic_flush_virqs() in vgic.h/c
