### PR TITLE
loading guest linux : add memory map description for guest linux

### DIFF
--- a/monitor/vmm.c
+++ b/monitor/vmm.c
@@ -68,19 +68,23 @@ static struct memmap_desc guest_md_empty[] = {
 
 static struct memmap_desc guest_device_md0[] = {
     /*  label, ipa       , pa        ,       size, attr */
-    //{  "uart", 0x3FCA0000, 0x1C090000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {  "uart", 0x1C090000, 0x1C090000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
-    /* UNMAP {  "gicd", 0x2C001000, 0x2C001000,     0x1000, LPAED_STAGE2_MEMATTR_DM }, */
-    {  "gicc", CFG_GIC_BASE_PA | GIC_OFFSET_GICC, CFG_GIC_BASE_PA | GIC_OFFSET_GICVI,     0x2000, LPAED_STAGE2_MEMATTR_DM },
-    {   "timer0", 0x1c110000, 0x1c110000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {   "timer1", 0x1c120000, 0x1c120000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
     {   "sysreg", 0x1c010000, 0x1c010000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
     {   "sysctl", 0x1c020000, 0x1c020000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
     {   "aaci", 0x1c040000, 0x1c040000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {   "wdt", 0x1c0F0000, 0x1c0F0000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {   "rtc", 0x1c170000, 0x1c170000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
     {   "mmci", 0x1c050000, 0x1c050000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
     {   "kmi", 0x1c060000, 0x1c060000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
+    {   "kmi2", 0x1c070000, 0x1c070000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
+    {  "v2m_serial0", 0x1C090000, 0x1C090000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
+    {  "v2m_serial1", 0x1C0a0000, 0x1C0a0000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
+    {  "v2m_serial2", 0x1C0b0000, 0x1C0b0000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
+    {  "v2m_serial3", 0x1C0c0000, 0x1C0c0000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
+    {   "wdt", 0x1c0F0000, 0x1c0F0000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
+    /* UNMAP {  "gicd", 0x2C001000, 0x2C001000,     0x1000, LPAED_STAGE2_MEMATTR_DM }, */
+    {  "gicc", CFG_GIC_BASE_PA | GIC_OFFSET_GICC, CFG_GIC_BASE_PA | GIC_OFFSET_GICVI,     0x2000, LPAED_STAGE2_MEMATTR_DM },
+    {   "v2m_timer01", 0x1c110000, 0x1c110000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
+    {   "v2m_timer23", 0x1c120000, 0x1c120000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
+    {   "rtc", 0x1c170000, 0x1c170000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
+    {   "clcd", 0x1c1f0000, 0x1c1f0000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
     {       0, 0, 0, 0,  0},
 };
 


### PR DESCRIPTION
add device memory using the rtsm_ve-motherboard.dtsi
