### PR TITLE
v1-arndale : run guest0/1 on arndale board

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ $ make arndale5250
 </pre>
 4. refusing SD card for arndale(X is number of SD card parition)
 <pre>
-$ sudo dd if=spl/smdk5250-spl.bin of=/dev/sdX bs=512 seek=17i
+$ sudo dd if=spl/smdk5250-spl.bin of=/dev/sdX bs=512 seek=17
 $ sudo dd if=u-boot.bin of=/dev/sdX bs=512 seek=49
 $ sudo dd if=hvc-man-switch.bin of=/dev/sdX bs=512 seek=1105
 $ sudo dd if=bmguest.bin of=/dev/sdX bs=512 seek=2129

--- a/README.md
+++ b/README.md
@@ -82,17 +82,23 @@ $ git submodule init
 $ git submodule update
 $ cd u-boot-arndale
 </pre>
-2. Building u-boot-arndale
+2. patching a autoboot for u-boot-arndale
 <pre>
 $ git checkout lue_arndale_13.1
+$ patch -p1 < ../patch/u-boot_arndale.patch
+</pre>
+3. Building u-boot-arndale
+<pre>
 $ make arndale5250
 </pre>
-3. refusing SD card for arndale(X is number of SD card parition)
+4. refusing SD card for arndale(X is number of SD card parition)
 <pre>
-$ sudo dd if=spl/smdk5250-spl.bin of=/dev/sdX bs=512 seek=17
+$ sudo dd if=spl/smdk5250-spl.bin of=/dev/sdX bs=512 seek=17i
 $ sudo dd if=u-boot.bin of=/dev/sdX bs=512 seek=49
+$ sudo dd if=hvc-man-switch.bin of=/dev/sdX bs=512 seek=1105
+$ sudo dd if=bmguest.bin of=/dev/sdX bs=512 seek=2129
 </pre>
-4. Loading khypervisor to arndale board using CODEVISOR debugger
+5. Loading khypervisor to arndale board using CODEVISOR debugger
 
 <blockquote>
 <pre>

--- a/bmguest/Makefile
+++ b/bmguest/Makefile
@@ -13,7 +13,11 @@ else
 include config-default.mk
 endif
 
+ifeq ($(ARNDALE),y)
+OBJS 		= guest.o c_start.o string.o exception.o gic.o arndale_uart_print.o test_vdev_sample.o test_sp804_timer.o
+else
 OBJS 		= guest.o c_start.o string.o exception.o gic.o uart_print.o test_vdev_sample.o test_sp804_timer.o
+endif
 
 GUESTIMG 	= bmguest.axf
 GUESTBIN	= bmguest.bin

--- a/bmguest/Makefile
+++ b/bmguest/Makefile
@@ -17,12 +17,12 @@ else
 include config-default.mk
 endif
 
-OBJS = guest.o c_start.o string.o exception.o gic.o test_vdev_sample.o test_sp804_timer.o
+OBJS = guest.o c_start.o string.o exception.o gic.o test_vdev_sample.o
 
 ifeq ($(ARNDALE),y)
 OBJS += arndale_uart_print.o test_pwm_timer.o
 else
-OBJS += uart_print.o
+OBJS += uart_print.o test_sp804_timer.o
 endif
 
 GUESTIMG 	= bmguest.axf
@@ -46,10 +46,6 @@ GUESTTYPE?=GUEST_HYPMON
 
 GUESTCONFIGS	=
 
-ifeq ($(ARNDALE),y)
-GUESTCONFIGS += -DARNDALE
-endif
-
 ifeq ($(GUESTTYPE),GUEST_HYPMON)
 GUESTCONFIGS	= -D__MONITOR_CALL_HVC__ -DLDS_PHYS_OFFSET='0x80000000' -DLDS_GUEST_OFFSET='0x80000000' -DLDS_GUEST_STACK='0x8F000000'
 else
@@ -60,6 +56,10 @@ endif
 GUESTCONFIGS += -DNUM_ITERATIONS=300 -DGUEST_LABEL='"[guest0] "'
 GUESTCONFIGS += -DLDS_$(GUESTTYPE)=1
 
+
+ifeq ($(ARNDALE),y)
+GUESTCONFIGS += -DARNDALE
+endif
 
 #GUESTCONFIGS	= -D__MONITOR_CALL_HVC__
 # These are needed by the underlying kernel make

--- a/bmguest/Makefile
+++ b/bmguest/Makefile
@@ -5,6 +5,10 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE.txt file.
 
+# Usage: make [ARNDALE=y]
+# Example:
+# 	$ make ARBDALE=y 	; # build for ARNDALE board
+#	$ make 		; build for RTSM
 
 # Include config file (prefer config.mk, fall back to config-default.mk)
 ifneq ($(wildcard config.mk),)
@@ -13,10 +17,12 @@ else
 include config-default.mk
 endif
 
+OBJS = guest.o c_start.o string.o exception.o gic.o test_vdev_sample.o test_sp804_timer.o
+
 ifeq ($(ARNDALE),y)
-OBJS 		= guest.o c_start.o string.o exception.o gic.o arndale_uart_print.o test_vdev_sample.o test_sp804_timer.o
+OBJS += arndale_uart_print.o test_pwm_timer.o
 else
-OBJS 		= guest.o c_start.o string.o exception.o gic.o uart_print.o test_vdev_sample.o test_sp804_timer.o
+OBJS += uart_print.o
 endif
 
 GUESTIMG 	= bmguest.axf
@@ -39,6 +45,10 @@ GUESTTYPE?=GUEST_HYPMON
 #GUESTTYPE	= GUEST_HYPMON
 
 GUESTCONFIGS	=
+
+ifeq ($(ARNDALE),y)
+GUESTCONFIGS += -DARNDALE
+endif
 
 ifeq ($(GUESTTYPE),GUEST_HYPMON)
 GUESTCONFIGS	= -D__MONITOR_CALL_HVC__ -DLDS_PHYS_OFFSET='0x80000000' -DLDS_GUEST_OFFSET='0x80000000' -DLDS_GUEST_STACK='0x8F000000'

--- a/bmguest/arndale_uart_print.c
+++ b/bmguest/arndale_uart_print.c
@@ -1,43 +1,8 @@
 #include "uart_print.h"
+#include "exynos-uart.h"
 /* UART Base Address determined by Hypervisor's Stage 2 Translation Table */
-//#define UART0           0x3FCA0000
 #define UART0           0x1C090000
 static char _dummy_byte;
-
-
-#ifndef __ASSEMBLY__
-/* baudrate rest value */
-union br_rest {
-    unsigned short  slot;       /* udivslot */
-    unsigned char   value;      /* ufracval */
-};
-
-struct s5p_uart {
-    unsigned int    ulcon;
-    unsigned int    ucon;
-    unsigned int    ufcon;
-    unsigned int    umcon;
-    unsigned int    utrstat;
-    unsigned int    uerstat;
-    unsigned int    ufstat;
-    unsigned int    umstat;
-    unsigned char   utxh;
-    unsigned char   res1[3];
-    unsigned char   urxh;
-    unsigned char   res2[3];
-    unsigned int    ubrdiv;
-    union br_rest   rest;
-    unsigned char   res3[0xffd0];
-};
-
-static inline int s5p_uart_divslot(void)
-{
-    return 0;
-}
-
-#endif  /* __ASSEMBLY__ */
-
-
 
 /* Exynos 5250 UART register macros */
 #define UTXH        0x20

--- a/bmguest/arndale_uart_print.c
+++ b/bmguest/arndale_uart_print.c
@@ -1,0 +1,122 @@
+#include "uart_print.h"
+/* UART Base Address determined by Hypervisor's Stage 2 Translation Table */
+//#define UART0           0x3FCA0000
+#define UART0           0x1C090000
+static char _dummy_byte;
+
+
+#ifndef __ASSEMBLY__
+/* baudrate rest value */
+union br_rest {
+    unsigned short  slot;       /* udivslot */
+    unsigned char   value;      /* ufracval */
+};
+
+struct s5p_uart {
+    unsigned int    ulcon;
+    unsigned int    ucon;
+    unsigned int    ufcon;
+    unsigned int    umcon;
+    unsigned int    utrstat;
+    unsigned int    uerstat;
+    unsigned int    ufstat;
+    unsigned int    umstat;
+    unsigned char   utxh;
+    unsigned char   res1[3];
+    unsigned char   urxh;
+    unsigned char   res2[3];
+    unsigned int    ubrdiv;
+    union br_rest   rest;
+    unsigned char   res3[0xffd0];
+};
+
+static inline int s5p_uart_divslot(void)
+{
+    return 0;
+}
+
+#endif  /* __ASSEMBLY__ */
+
+
+
+/* Exynos 5250 UART register macros */
+#define UTXH        0x20
+#define UFSTAT      0x18
+#define UART_BASE   (UART0 + UTXH)
+
+#define TX_FIFO_FULL_MASK       (1 << 24)
+#define readl(a)         (*(volatile unsigned int *)(a))
+#define writeb(v, a)         (*(volatile unsigned char *)(a) = (v))
+
+static int serial_err_check(int op)
+{
+    struct s5p_uart *const uart = (struct s5p_uart *) UART0;
+    unsigned int mask;
+
+    if(op)
+        mask = 0x8;
+    else
+        mask = 0xf;
+
+    return readl(&uart->uerstat) & mask;
+
+}
+
+void uart_putc(const char c)
+{
+    struct s5p_uart *const uart = (struct s5p_uart *) UART0;
+
+
+    while((readl(&uart->ufstat) & TX_FIFO_FULL_MASK)) {
+        if (serial_err_check(1))
+            return;
+    }
+
+    writeb(c, &uart->utxh);
+
+    if(c == '\n')
+        uart_putc('\r');
+
+
+}
+void uart_print(const char *str)
+{
+    while(*str) {
+        uart_putc(*str++);
+    }
+}
+
+void uart_print_hex32( uint32_t v )
+{
+    unsigned int mask8 = 0xF;
+    unsigned int c;
+    int i;
+    uart_print("0x");
+
+    for ( i = 7; i >= 0; i-- ) {
+        c = (( v >> (i * 4) ) & mask8);
+        if ( c < 10 ) {
+            c += '0';
+        } else {
+            c += 'A' - 10;
+        }
+        uart_putc( (char) c );
+    }
+}
+
+void uart_print_hex64( uint64_t v )
+{
+    uart_print_hex32( v >> 32 );
+    uart_print_hex32( (uint32_t) (v & 0xFFFFFFFF) );
+}
+
+void uart_init(void)
+{
+    /* TODO:
+       Figure out how to initialize the UART.
+       Currently, intialized by Hypervisor for FastModels RTSM_VE, as a workaround
+     */
+    /* ibrd 0x24 */
+    //UART_BASE[9] = 0x10;
+    //UART_BASE[12] = 0xc300;
+}

--- a/bmguest/c_start.c
+++ b/bmguest/c_start.c
@@ -47,7 +47,7 @@
 inline void nrm_delay(void)
 {
 	volatile int i = 0;
-	for( i = 0; i < 0x00FFFFFF; i++);
+	for( i = 0; i < 0x00000FFF; i++);
 }
 
 
@@ -68,16 +68,16 @@ void nrm_loop(void)
      * - Uncomment the following line of code only if 'vdev_sample' is registered at the monitor
      * - Otherwise, the monitor will hang with data abort
      */
-    /* 
+     
     test_vdev_sample();
-    */
+    
 
     /* Test the SP804 timer */
     hvmm_tests_sp804_timer();
 
 	for( i = 0; i < NUM_ITERATIONS; i++ ) {
-		nrm_delay();
 		uart_print(GUEST_LABEL); uart_print("iteration "); uart_print_hex32( i ); uart_print( "\n\r" );
+		nrm_delay();
 
 #ifdef __MONITOR_CALL_HVC__
 	    /* Hyp monitor guest run in Non-secure supervisor mode. 

--- a/bmguest/c_start.c
+++ b/bmguest/c_start.c
@@ -27,9 +27,10 @@
 #include "uart_print.h"
 #include "gic.h"
 #include "tests.h"
-#include "test_sp804_timer.h"
 #ifdef ARNDALE
 #include "test_pwm_timer.h"
+#else
+#include "test_sp804_timer.h"
 #endif
 
 #ifdef __MONITOR_CALL_HVC__
@@ -74,12 +75,11 @@ void nrm_loop(void)
      
     test_vdev_sample();
     
-
-    /* Test the SP804 timer */
-    hvmm_tests_sp804_timer();
-
 #ifdef ARNDALE
     hvmm_tests_pwm_timer();
+#else
+    /* Test the SP804 timer */
+    hvmm_tests_sp804_timer();
 #endif
 
 	for( i = 0; i < NUM_ITERATIONS; i++ ) {

--- a/bmguest/c_start.c
+++ b/bmguest/c_start.c
@@ -28,6 +28,9 @@
 #include "gic.h"
 #include "tests.h"
 #include "test_sp804_timer.h"
+#ifdef ARNDALE
+#include "test_pwm_timer.h"
+#endif
 
 #ifdef __MONITOR_CALL_HVC__
 #define hsvc_ping()	asm("hvc #0xFFFE")
@@ -74,6 +77,10 @@ void nrm_loop(void)
 
     /* Test the SP804 timer */
     hvmm_tests_sp804_timer();
+
+#ifdef ARNDALE
+    hvmm_tests_pwm_timer();
+#endif
 
 	for( i = 0; i < NUM_ITERATIONS; i++ ) {
 		uart_print(GUEST_LABEL); uart_print("iteration "); uart_print_hex32( i ); uart_print( "\n\r" );

--- a/bmguest/exynos-uart.h
+++ b/bmguest/exynos-uart.h
@@ -1,0 +1,59 @@
+/*
+ * (C) Copyright 2009 Samsung Electronics
+ * Minkyu Kang <mk7.kang@samsung.com>
+ * Heungjun Kim <riverful.kim@samsung.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+ * MA 02111-1307 USA
+ *
+ */
+
+#ifndef __ASM_ARCH_UART_H_
+#define __ASM_ARCH_UART_H_
+
+#ifndef __ASSEMBLY__
+/* baudrate rest value */
+union br_rest {
+        unsigned short        slot;                /* udivslot */
+        unsigned char        value;                /* ufracval */
+};
+
+struct s5p_uart {
+        unsigned int        ulcon;
+        unsigned int        ucon;
+        unsigned int        ufcon;
+        unsigned int        umcon;
+        unsigned int        utrstat;
+        unsigned int        uerstat;
+        unsigned int        ufstat;
+        unsigned int        umstat;
+        unsigned char        utxh;
+        unsigned char        res1[3];
+        unsigned char        urxh;
+        unsigned char        res2[3];
+        unsigned int        ubrdiv;
+        union br_rest        rest;
+        unsigned char        res3[0xffd0];
+};
+
+static inline int s5p_uart_divslot(void)
+{
+        return 0;
+}
+
+#endif        /* __ASSEMBLY__ */
+
+#endif
+

--- a/bmguest/io-exynos.h
+++ b/bmguest/io-exynos.h
@@ -1,0 +1,22 @@
+#ifndef __IO_EXYNOS_H__
+#define __IO_EXYNOS_H_
+/*
+ * For write data on physical address.
+ */
+#include "arch_types.h"
+#include "asm-arm_inline.h"
+#define __raw_write32(a, v) (*(volatile uint32_t *)(a) = (v))
+#define __raw_read32(a)     (*(volatile uint32_t *)(a))
+#define __iowmb()   dsb()
+#define __iormb()   dsb()
+#define arch_out_le32(a, v) {__iowmb(); __raw_write32(a, v); }
+#define arch_in_le32(a) ({uint32_t v = __raw_read32(a); __iormb(); v; })
+static inline uint32_t vmm_readl(volatile void *addr)
+{     
+    return arch_in_le32(addr);
+} 
+static inline void vmm_writel(uint32_t data, volatile void *addr)
+{
+    arch_out_le32(addr, data);
+}
+#endif

--- a/bmguest/test_pwm_timer.c
+++ b/bmguest/test_pwm_timer.c
@@ -1,0 +1,124 @@
+#include <gic.h>
+#include "hvmm_trace.h"
+#include "armv7_p15.h"
+#include "uart_print.h"
+#include "test_pwm_timer.h"
+#include "io-exynos.h"
+
+
+uint32_t tcntb1; 
+static pwm_timer_callback_t _callback;
+
+
+hvmm_status_t pwm_timer_enable_int()
+{
+    uint32_t tcon;
+    uint32_t tcstat;
+    HVMM_TRACE_ENTER();
+    tcon = vmm_readl(TCON);
+    tcstat = vmm_readl(CSTAT); 
+    //auto reload set & timer start
+    tcon |= (TCON_T1RELOAD);
+    tcon |= (TCON_T1START);
+    vmm_writel(tcon, TCON);
+    //interrupt enable
+    tcstat |= 1 << 1;
+    vmm_writel(tcstat, CSTAT);
+    HVMM_TRACE_EXIT();
+    return HVMM_STATUS_SUCCESS;
+
+}
+hvmm_status_t pwm_timer_disable_int()
+{
+    uint32_t tcstat;
+    uint32_t tcon;
+
+    /* Stop pwm timer1 */
+    tcon = vmm_readl(TCON);
+    tcon &= ~(1 << 8);
+    vmm_writel(tcon, TCON);    
+    /* Disable Pwm timer1 Interrupt */  
+    tcstat = vmm_readl(CSTAT);
+    tcstat &= ~(1 << 1);
+    vmm_writel(tcstat, CSTAT); 
+    return HVMM_STATUS_SUCCESS;
+}
+hvmm_status_t pwm_timer_set_interval(uint32_t interval)
+{
+    tcntb1 = 16500;
+    return HVMM_STATUS_SUCCESS;
+}
+static void _pwm_timer_irq_handler(int irq, void *regs, void *pdata)
+{
+   _callback(regs); 
+}
+hvmm_status_t pwm_timer_enable_irq()
+{
+    hvmm_status_t result = HVMM_STATUS_UNSUPPORTED_FEATURE;
+    /* handler */
+    gic_enable_irq(69);
+    /* configure and enable interrupt */
+    gic_set_irq_handler(69, interrupt_pwmtimer, 0);
+    result = HVMM_STATUS_SUCCESS;
+    return result;
+   
+}
+hvmm_status_t pwm_timer_set_callback(pwm_timer_callback_t callback)
+{
+    _callback = callback;
+    return HVMM_STATUS_SUCCESS;
+}
+
+void pwm_timer_init()
+{
+    uint32_t tcfg0;
+    uint32_t tcfg1;
+    uint32_t tcon;
+
+    pwm_timer_set_interval(0);
+    pwm_timer_enable_irq(); 
+
+    tcfg0 = vmm_readl(TCFG0);
+    tcfg1 = vmm_readl(TCFG1);
+    tcon = vmm_readl(TCON);
+    /* prescaler */
+    tcfg0 &= ~(0xff);
+    tcfg0 |= 250-1;
+    vmm_writel(tcfg0, TCFG0);
+    /* mux */
+    tcfg1 &= ~(0xf<<4);
+    tcfg1 |= (0x3<<4);
+    vmm_writel(tcfg1, TCFG1);
+    /* count buffer resister */
+    vmm_writel(tcntb1,TCNTB(1));
+    /* count buffer resister load */
+    tcon |= TCON_T1MANUALUPD;
+    vmm_writel(tcon, TCON);
+    tcon &= ~(TCON_T1MANUALUPD);
+    vmm_writel(tcon, TCON);
+}
+void interrupt_pwmtimer(int irq, void *pregs, void *pdata )
+{
+    pwm_timer_disable_int();
+
+    uart_print( "=======================================\n\r" );
+    HVMM_TRACE_ENTER();
+
+    HVMM_TRACE_EXIT();
+    uart_print( "=======================================\n\r" );
+
+    pwm_timer_enable_int();
+}
+
+hvmm_status_t hvmm_tests_pwm_timer(void)
+{
+    /* Testing pwm timer event (timer1, Interrupt ID : 69), Cortex-A15 exynos5250
+         * - Periodically triggers timer interrupt
+     * - Just print uart_print
+     */
+        HVMM_TRACE_ENTER();
+    pwm_timer_init();
+    pwm_timer_enable_int();
+        HVMM_TRACE_EXIT();
+        return HVMM_STATUS_SUCCESS;
+}

--- a/bmguest/test_pwm_timer.h
+++ b/bmguest/test_pwm_timer.h
@@ -1,0 +1,47 @@
+#ifndef __TESTS_PWM_TIMER_H__
+#define __TESTS_PWM_TIMER_H__
+
+#include <hvmm_types.h>
+
+//For Guest OS
+#define PWMBASE (void*)0x3FD10000
+#define PWM_TIMERREG(x) (PWMBASE + (x))
+#define TCFG0   PWM_TIMERREG(0x00)
+#define TCFG1   PWM_TIMERREG(0x04)
+#define TCON    PWM_TIMERREG(0x08)
+#define PWM_TIMERREG2(tmr,reg) PWM_TIMERREG((reg)+0x0c+((tmr)*0x0c))
+#define CSTAT PWM_TIMERREG(0x44)
+#define TCNTB(tmr)  PWM_TIMERREG2(tmr, 0x00)
+#define TCMPB(tmr)  PWM_TIMERREG2(tmr, 0x04)
+#define TCNTO(tmr)  PWM_TIMERREG2(tmr, (((tmr) == 4) ? 0x04 : 0x08))
+#define TCON_T4RELOAD       (1<<22)
+#define TCON_T4MANUALUPD    (1<<21)
+#define TCON_T4START        (1<<20)
+#define TCON_T0RELOAD       (1<<3)
+#define TCON_T0MANUALUPD    (1<<1)
+#define TCON_T0START        (1<<0)
+#define TCON_T2RELOAD       (1<<15)
+#define TCON_T2MANUALUPD    (1<<13)
+#define TCON_T2START        (1<<12)
+#define TCON_T1MANUALUPD    (1<<9)
+#define TCON_T1START        (1<<8)
+#define TCON_T1RELOAD       (1<<11)
+
+typedef void (*pwm_timer_callback_t)(void *pdata);
+
+/* Initialize pwm timer 1 */
+void pwm_timer_init();
+/* enable the timer.   */
+hvmm_status_t pwm_timer_enable_int();
+/* Disable the timer.  */
+hvmm_status_t pwm_timer_disable_int();
+/* Sets time interval. Converts from microseconds to count and sets time interval.*/
+hvmm_status_t pwm_timer_set_interval(uint32_t tval);
+/* Enables timer irq.  */
+hvmm_status_t pwm_timer_enable_irq();
+/* Adds callback funtion. Called when occur timer interrupt */
+hvmm_status_t pwm_timer_set_callback(pwm_timer_callback_t callback);
+hvmm_status_t hvmm_tests_pwm_timer(void);
+void interrupt_pwmtimer(int irq, void *pregs, void *pdata );
+
+#endif

--- a/bmguest/uart_print.c
+++ b/bmguest/uart_print.c
@@ -1,4 +1,3 @@
-
 /* UART Base Address determined by Hypervisor's Stage 2 Translation Table */
 #define UART_BASE       ((volatile unsigned int *) 0x1C090000)
 
@@ -17,15 +16,15 @@ void uart_init(void)
 
 void uart_print(char *str)
 {
-        char *pUART = (char *) UART_BASE;
-        while(*str) {
-                *pUART = *str++;
-        }
+    char *pUART = (char *) UART_BASE;
+    while(*str) {
+            *pUART = *str++;
+    }
 }
 
-void uart_putc( char c )
+void uart_putc(char c )
 {
-        volatile char *pUART = (char *) UART_BASE;
+    volatile char *pUART = (char *) UART_BASE;
 	*pUART = c;
 }
 

--- a/common/include/hvmm_types.h
+++ b/common/include/hvmm_types.h
@@ -4,6 +4,7 @@
 #include <arch_types.h>
 #define VMID_INVALID    0xFF
 #define PIRQ_INVALID    0xFFFFFFFF
+#define VIRQ_INVALID    PIRQ_INVALID
 
 typedef enum {
 	HVMM_STATUS_SUCCESS = 0,

--- a/monitor/boot.S
+++ b/monitor/boot.S
@@ -161,7 +161,7 @@ start:
 #ifdef MACH_MPS
 	ldr	r0, =0x1f005000			@ UART3 base (MPS)
 #elif defined (CFG_BOARD_RTSM_VE_CA15)
-	ldr	r0, =CFG_UART0			@ UART base (Versatile Express)
+	ldr	r0, =0x1c090000			@ UART base (Versatile Express)
 #else
 	ldr	r0, =0x10009000			@ UART base (RealView/EB)
 #endif
@@ -178,14 +178,14 @@ start:
 #if defined (CFG_BOARD_RTSM_VE_CA15)
     /* Initialize UART1 and UART2 for access from guests, as a workaround, 
        since initialization sequence in C, in guest, is not clear a the moment */
-	ldr	r0, =CFG_UART1			@ UART base (Versatile Express)
+	ldr	r0, =0x1c0a0000			@ UART base (Versatile Express)
 	mov	r1, #0x10			@ ibrd
 	str	r1, [r0, #0x24]
 	mov	r1, #0xc300
 	orr	r1, #0x0001			@ cr
 	str	r1, [r0, #0x30]
 
-	ldr	r0, =CFG_UART2			@ UART base (Versatile Express)
+	ldr	r0, =0x1c0b0000			@ UART base (Versatile Express)
 	mov	r1, #0x10			@ ibrd
 	str	r1, [r0, #0x24]
 	mov	r1, #0xc300

--- a/monitor/boot.S
+++ b/monitor/boot.S
@@ -161,7 +161,7 @@ start:
 #ifdef MACH_MPS
 	ldr	r0, =0x1f005000			@ UART3 base (MPS)
 #elif defined (CFG_BOARD_RTSM_VE_CA15)
-	ldr	r0, =0x1c090000			@ UART base (Versatile Express)
+	ldr	r0, =CFG_UART0			@ UART base (Versatile Express)
 #else
 	ldr	r0, =0x10009000			@ UART base (RealView/EB)
 #endif
@@ -178,20 +178,27 @@ start:
 #if defined (CFG_BOARD_RTSM_VE_CA15)
     /* Initialize UART1 and UART2 for access from guests, as a workaround, 
        since initialization sequence in C, in guest, is not clear a the moment */
-	ldr	r0, =0x1c0A0000			@ UART base (Versatile Express)
+	ldr	r0, =CFG_UART1			@ UART base (Versatile Express)
 	mov	r1, #0x10			@ ibrd
 	str	r1, [r0, #0x24]
 	mov	r1, #0xc300
 	orr	r1, #0x0001			@ cr
 	str	r1, [r0, #0x30]
 
-	ldr	r0, =0x1c0B0000			@ UART base (Versatile Express)
+	ldr	r0, =CFG_UART2			@ UART base (Versatile Express)
 	mov	r1, #0x10			@ ibrd
 	str	r1, [r0, #0x24]
 	mov	r1, #0xc300
 	orr	r1, #0x0001			@ cr
 	str	r1, [r0, #0x30]
 #endif
+/* Initialize bss section */
+    ldr  r2, =begin_bss
+    ldr  r3, =end_bss
+    mov  r0, #0
+1:  str  r0, [r2], #4    @ clear bss
+    cmp  r2, r3
+    blo  1b
 	@ Now we've got rid of the secondary CPUs, set up a stack
 	@ for CPU 0 so we can write most of this in C.
 	ldr     sp, =sec_stacklimit

--- a/monitor/context.c
+++ b/monitor/context.c
@@ -331,12 +331,16 @@ static hvmm_status_t context_perform_switch_to_guest_regs(struct arch_regs *regs
 	vmm_stage2_enable(1);
     vgic_restore_status( &context->vgic_status, context->vmid );
     
-    printh( "context: restoring vmid[%d] mode(%x):%s pc:0x%x\n", 
+    {
+        uint32_t lr = 0;
+        asm volatile( "mov  %0, lr" : "=r" (lr) : : "memory", "cc");
+        printh( "context: restoring vmid[%d] mode(%x):%s pc:0x%x lr:0x%x\n", 
             next_vmid, 
             context->regs.cpsr & 0x1F, 
             _modename(context->regs.cpsr & 0x1F),
-            context->regs.pc
-   );
+            context->regs.pc, lr
+        );
+    }
 
     /* The next becomes the current */
     _current_guest_vmid = next_vmid;

--- a/monitor/devices/gic/slotpirq.c
+++ b/monitor/devices/gic/slotpirq.c
@@ -5,6 +5,7 @@
 /* SLOT:PIRQ mapping */
 
 static uint32_t _guest_pirqatslot[NUM_GUESTS_STATIC][VGIC_NUM_MAX_SLOTS];
+static uint32_t _guest_virqatslot[NUM_GUESTS_STATIC][VGIC_NUM_MAX_SLOTS];
 
 void slotpirq_init(void)
 {
@@ -12,6 +13,7 @@ void slotpirq_init(void)
     for( i = 0; i < NUM_GUESTS_STATIC; i++ ) {
         for( j = 0; j < VGIC_NUM_MAX_SLOTS; j++ ) {
             _guest_pirqatslot[i][j] = PIRQ_INVALID;
+            _guest_virqatslot[i][j] = VIRQ_INVALID;
         }
     }
 }
@@ -39,3 +41,37 @@ void slotpirq_clear(vmid_t vmid, uint32_t slot)
 {
     slotpirq_set(vmid, slot, PIRQ_INVALID);
 }
+
+void slotvirq_set( vmid_t vmid, uint32_t slot, uint32_t virq )
+{
+    if ( vmid < NUM_GUESTS_STATIC ) {
+        printh( "vgic: setting vmid:%d slot:%d virq:%d\n", vmid, slot, virq );
+        _guest_virqatslot[vmid][slot] = virq;
+    } else {
+        printh( "vgic: not setting invalid vmid:%d slot:%d virq:%d\n", vmid, slot, virq );
+    }
+}
+
+uint32_t slotvirq_getslot(vmid_t vmid, uint32_t virq)
+{
+    uint32_t slot = SLOT_INVALID;
+    int i;
+
+    if ( vmid < NUM_GUESTS_STATIC ) {
+        for ( i = 0; i < VGIC_NUM_MAX_SLOTS; i++ ) {
+            if ( _guest_virqatslot[vmid][i] == virq ) {
+                slot = i;
+                printh( "vgic: reading vmid:%d slot:%d virq:%d\n", vmid, slot, virq );
+                break;
+            }
+        }
+    }
+    return slot;
+}
+
+void slotvirq_clear(vmid_t vmid, uint32_t slot)
+{
+    slotvirq_set(vmid, slot, VIRQ_INVALID);
+}
+
+

--- a/monitor/devices/gic/vgic.c
+++ b/monitor/devices/gic/vgic.c
@@ -214,6 +214,7 @@ static void _vgic_isr_maintenance_irq(int irq, void *pregs, void *pdata)
             } else {
                 printh( "vgic: deactivated virq at slot %d\n", slot );
             }
+            slotvirq_clear(vmid, slot);
         }
 
         eisr = _vgic.base[GICH_EISR1];
@@ -231,6 +232,7 @@ static void _vgic_isr_maintenance_irq(int irq, void *pregs, void *pdata)
             } else {
                 printh( "vgic: deactivated virq at slot %d\n", slot );
             }
+            slotvirq_clear(vmid, slot);
         }
     }
 
@@ -248,17 +250,24 @@ static void _vgic_isr_maintenance_irq(int irq, void *pregs, void *pdata)
             }
         }
     }
+    
+    {
+      uint64_t elsr;
+      elsr = _vgic.base[GICH_ELSR1];
+      elsr <<= 32;
+      elsr |= _vgic.base[GICH_ELSR0];
 
-    if ( ((~(_vgic.base[GICH_ELSR0])) | (~(_vgic.base[GICH_ELSR1]))) == 0 ) {
+      if ( ((~elsr) & _vgic.valid_lr_mask) == 0 ) {
         /* No valid interrupt */
-        vgic_enable(0);
-        vgic_injection_enable(0);
-        printh( "vgic: no valid virqs, disabling vgic\n" );
-    } else {
-        printh( "vgic:MISR:%x ELSR0:%x ELSR1:%x\n",
-            _vgic.base[GICH_MISR], 
-            _vgic.base[GICH_ELSR0],
-            _vgic.base[GICH_ELSR1]);
+          vgic_enable(0);
+          vgic_injection_enable(0);
+          printh( "vgic: no valid virqs, disabling vgic\n" );
+     } else {
+          printh( "vgic:MISR:%x ELSR0:%x ELSR1:%x\n",
+               _vgic.base[GICH_MISR], 
+               _vgic.base[GICH_ELSR0],
+               _vgic.base[GICH_ELSR1]);
+        }
     }
 
     HVMM_TRACE_EXIT();

--- a/monitor/devices/uart-exynos5250/uart_print.c
+++ b/monitor/devices/uart-exynos5250/uart_print.c
@@ -4,7 +4,7 @@
 
 #ifdef CFG_EXYNOS5250
 #ifdef CFG_BOARD_ARNDALE
-#define UART2       	CFG_UART0
+#define UART2_BASE       	0x12c20000
 #else
 #error "Configuration for board is not specified! Exynos5250 but board is unknow."
 #endif
@@ -20,7 +20,7 @@
 
 static int serial_err_check(int op)
 {
-	struct s5p_uart *const uart = (struct s5p_uart *) UART2;
+	struct s5p_uart *const uart = (struct s5p_uart *) UART2_BASE;
 	unsigned int mask;
 
 	if(op)
@@ -34,7 +34,7 @@ static int serial_err_check(int op)
 
 void uart_putc(const char c)
 {
-	struct s5p_uart *const uart = (struct s5p_uart *) UART2;
+	struct s5p_uart *const uart = (struct s5p_uart *) UART2_BASE;
 
 
 	while((readl(&uart->ufstat) & TX_FIFO_FULL_MASK)) {

--- a/monitor/devices/uart-exynos5250/uart_print.c
+++ b/monitor/devices/uart-exynos5250/uart_print.c
@@ -4,7 +4,7 @@
 
 #ifdef CFG_EXYNOS5250
 #ifdef CFG_BOARD_ARNDALE
-#define UART0       	0x12c20000
+#define UART2       	CFG_UART0
 #else
 #error "Configuration for board is not specified! Exynos5250 but board is unknow."
 #endif
@@ -20,7 +20,7 @@
 
 static int serial_err_check(int op)
 {
-	struct s5p_uart *const uart = (struct s5p_uart *) UART0;
+	struct s5p_uart *const uart = (struct s5p_uart *) UART2;
 	unsigned int mask;
 
 	if(op)
@@ -34,7 +34,7 @@ static int serial_err_check(int op)
 
 void uart_putc(const char c)
 {
-	struct s5p_uart *const uart = (struct s5p_uart *) UART0;
+	struct s5p_uart *const uart = (struct s5p_uart *) UART2;
 
 
 	while((readl(&uart->ufstat) & TX_FIFO_FULL_MASK)) {

--- a/monitor/devices/uart-pl011/uart_print.c
+++ b/monitor/devices/uart-pl011/uart_print.c
@@ -4,7 +4,7 @@
 
 #ifdef CFG_GENERIC_CA15
 #ifdef CFG_BOARD_RTSM_VE_CA15
-#define UART_BASE       CFG_UART0
+#define UART0_BASE       0x1C090000
 #else
 #error "Configuration for board is not specified! GENERIC_CA15 but board is unknown."
 #endif
@@ -12,7 +12,7 @@
 
 void uart_print(const char *str)
 {
-        volatile char *pUART = (char *) UART_BASE;
+        volatile char *pUART = (char *) UART0_BASE;
         while(*str) {
                 *pUART = *str++;
         }
@@ -20,7 +20,7 @@ void uart_print(const char *str)
 
 void uart_putc( const char c )
 {
-        volatile char *pUART = (char *) UART_BASE;
+        volatile char *pUART = (char *) UART0_BASE;
 	*pUART = c;
 }
 

--- a/monitor/devices/uart-pl011/uart_print.c
+++ b/monitor/devices/uart-pl011/uart_print.c
@@ -4,7 +4,7 @@
 
 #ifdef CFG_GENERIC_CA15
 #ifdef CFG_BOARD_RTSM_VE_CA15
-#define UART_BASE       0x1c090000
+#define UART_BASE       CFG_UART0
 #else
 #error "Configuration for board is not specified! GENERIC_CA15 but board is unknown."
 #endif

--- a/monitor/hmain.c
+++ b/monitor/hmain.c
@@ -40,7 +40,7 @@ void hyp_main(void)
 
     /* Virtual GIC Distributor */
     printh( "tests: Registering sample vdev:'vgicd' at %x\n", CFG_GIC_BASE_PA | GIC_OFFSET_GICD);
-    vdev_gicd_init(CFG_GIC_BASE_PA | GIC_OFFSET_GICD);
+    vdev_gicd_init(0x2c000000 | GIC_OFFSET_GICD);
 
     /* Initialize PIRQ to VIRQ mapping */
     virqmap_init();

--- a/monitor/include/slotpirq.h
+++ b/monitor/include/slotpirq.h
@@ -2,9 +2,14 @@
 #define __SLOTPIRQ_H__
 #include <arch_types.h>
 #include <hvmm_types.h>
+#define SLOT_INVALID        0xFFFFFFFF
 
 void slotpirq_init(void);
 void slotpirq_set( vmid_t vmid, uint32_t slot, uint32_t pirq );
 uint32_t slotpirq_get(vmid_t vmid, uint32_t slot);
 void slotpirq_clear(vmid_t vmid, uint32_t slot);
+void slotvirq_set( vmid_t vmid, uint32_t slot, uint32_t virq );
+uint32_t slotvirq_getslot(vmid_t vmid, uint32_t virq);
+void slotvirq_clear(vmid_t vmid, uint32_t slot);
+
 #endif

--- a/monitor/mm.c
+++ b/monitor/mm.c
@@ -6,6 +6,7 @@
 #include "armv7_p15.h"
 #include "arch_types.h"
 #include "print.h"
+#include <memmap.cfg>
 
 /* LPAE Memory region attributes, to match Linux's (non-LPAE) choices.
  * Indexed by the AttrIndex bits of a LPAE entry;
@@ -96,8 +97,8 @@
 /* PL2 Stage 1 Level 3 */
 #define HMM_L3_PTE_NUM  512
 
-#define HEAP_ADDR 0xF2000000
-#define HEAP_SIZE 0xD000000
+#define HEAP_ADDR CFG_MEMMAP_MON_OFFSET + 0x02000000
+#define HEAP_SIZE 0x0D000000
 
 #define L2_ENTRY_MASK 0x1FF
 #define L2_SHIFT 21

--- a/monitor/model.lds.S
+++ b/monitor/model.lds.S
@@ -93,17 +93,23 @@ SECTIONS
   * where it won't get overwritten by kernel, initrd or atags.
   */
  .text : { 
-	boot.o(.text) 
-	monitor.o(.text) 
+    *(.text)
  }
+ .= ALIGN(4);
+ .rodata : {
+        *(.rodata)
+ }
+ .= ALIGN(4);
  .data : { 
-	boot.o(.data) 
-	monitor.o(.data) 
+    *(.data)
  }
+ .= ALIGN(4);
+ begin_bss = .;
  .bss : { 
-	boot.o(.bss) 
-	monitor.o(.bss) 
+    *(.bss)
  }
+ end_bss = .;
+
  . = MON_STACK;
  mon_stacktop = .;
  . = MON_STACK + MON_STACK_SIZE;

--- a/monitor/plat/exynos5250/arndale/cfg_platform.h
+++ b/monitor/plat/exynos5250/arndale/cfg_platform.h
@@ -4,9 +4,9 @@
 #define CFG_BOARD_ARNDALE
 #define CFG_EXYNOS5250
 #define CFG_CNTFRQ          24000000
-#define CFG_UART2         0x12C00000 // uart2
+#define CFG_UART2         0x12C00000 // uart0
 #define CFG_UART1         0x12C10000 // uart1
-#define CFG_UART0         0x12C20000 // uart0
+#define CFG_UART0         0x12C20000 // uart2
 
 /*
  *  SOC param

--- a/monitor/plat/exynos5250/arndale/cfg_platform.h
+++ b/monitor/plat/exynos5250/arndale/cfg_platform.h
@@ -4,6 +4,9 @@
 #define CFG_BOARD_ARNDALE
 #define CFG_EXYNOS5250
 #define CFG_CNTFRQ          24000000
+#define CFG_UART2         0x12C00000 // uart2
+#define CFG_UART1         0x12C10000 // uart1
+#define CFG_UART0         0x12C20000 // uart0
 
 /*
  *  SOC param

--- a/monitor/plat/generic_ca15/rtsmve_ca15/cfg_platform.h
+++ b/monitor/plat/generic_ca15/rtsmve_ca15/cfg_platform.h
@@ -4,6 +4,9 @@
 #define CFG_BOARD_RTSM_VE_CA15
 #define CFG_GENERIC_CA15
 #define CFG_CNTFRQ          100000000
+#define CFG_UART2         0x1C0B0000
+#define CFG_UART1         0x1C0A0000
+#define CFG_UART0         0x1C090000
 /*
  *  SOC param
  */

--- a/monitor/tests.c
+++ b/monitor/tests.c
@@ -13,7 +13,6 @@
 /* #define TESTS_ENABLE_MALLOC */
 #define TESTS_ENABLE_VGIC 
 #define TESTS_VDEV 
-/* #define TESTS_VDEV_VGICD */
 #define TESTS_ENABLE_SP804
 
 hvmm_status_t hvmm_tests_main(void)

--- a/monitor/tests.c
+++ b/monitor/tests.c
@@ -10,11 +10,11 @@
 /* GIC/Timer test disabled due to scheduler test does context switching based on timer ticks */
 /* #define TESTS_ENABLE_GIC_TIMER */
 /* #define TESTS_ENABLE_GIC_PWM_TIMER */
-#define TESTS_ENABLE_MALLOC
-/* #define TESTS_ENABLE_VGIC */
-/* #define TESTS_VDEV */
-/* #define TESTS_VDEV_VGICD */
-/* #define TESTS_ENABLE_SP804 */
+/* #define TESTS_ENABLE_MALLOC */
+#define TESTS_ENABLE_VGIC 
+#define TESTS_VDEV 
+#define TESTS_VDEV_VGICD
+#define TESTS_ENABLE_SP804
 
 hvmm_status_t hvmm_tests_main(void)
 {

--- a/monitor/tests.c
+++ b/monitor/tests.c
@@ -13,7 +13,7 @@
 /* #define TESTS_ENABLE_MALLOC */
 #define TESTS_ENABLE_VGIC 
 #define TESTS_VDEV 
-#define TESTS_VDEV_VGICD
+/* #define TESTS_VDEV_VGICD */
 #define TESTS_ENABLE_SP804
 
 hvmm_status_t hvmm_tests_main(void)

--- a/monitor/vdev/vdev.c
+++ b/monitor/vdev/vdev.c
@@ -51,7 +51,7 @@ hvmm_status_t vdev_emulate(uint32_t fipa, uint32_t wnr, vdev_access_size_t acces
     int i = 0;
     uint32_t offset;
     uint8_t isize = 4;
-
+    vmid_t vmid = context_current_vmid();
     HVMM_TRACE_ENTER();
     if ( regs->cpsr & 0x20 ) {
         /* Thumb */
@@ -64,7 +64,7 @@ hvmm_status_t vdev_emulate(uint32_t fipa, uint32_t wnr, vdev_access_size_t acces
         offset = fipa - vdev_list[i].base;
         if ( fipa >= vdev_list[i].base && offset < vdev_list[i].size && vdev_list[i].handler != 0) {
             /* fipa is in the rage: base ~ base + size */
-            printh("vdev: found %s for fipa %x srt:%x gpr[srt]:%x write:%d\n", vdev_list[i].name, fipa, srt, regs->gpr[srt], wnr );
+            printh("vdev: found %s for fipa %x srt:%x gpr[srt]:%x write:%d vmid:%d\n", vdev_list[i].name, fipa, srt, regs->gpr[srt], wnr, vmid );
             result = vdev_list[i].handler(wnr, offset, &(regs->gpr[srt]), access_size);
             if ( wnr == 0 ) {
                 printh("vdev: result:%x\n", regs->gpr[srt] );

--- a/monitor/virqmap.c
+++ b/monitor/virqmap.c
@@ -33,6 +33,7 @@ hvmm_status_t virqmap_init(void)
 
     // NOTE(wonseok): referenced by https://github.com/kesl/khypervisor/wiki/Hardware-Resources-of-Guest-Linux-on-FastModels-RTSM_VE-Cortex-A15x1
 
+    // Test vgicd look bmguest/gic.c
     _virqmap[1].virq = 1;
     _virqmap[1].vmid = 0;
     _virqmap[31].virq = 31;
@@ -47,6 +48,12 @@ hvmm_status_t virqmap_init(void)
     _virqmap[18].vmid = 0;
     _virqmap[19].virq = 19;
     _virqmap[19].vmid = 0;
+
+    // pwm timer driver
+    // IRQ 69
+    _virqmap[69].virq = 69;
+    _virqmap[69].vmid = 0;
+    
     // WDT: shared driver
     // IRQ 32
     _virqmap[32].virq = 32;

--- a/monitor/virqmap.c
+++ b/monitor/virqmap.c
@@ -33,8 +33,22 @@ hvmm_status_t virqmap_init(void)
 
     // NOTE(wonseok): referenced by https://github.com/kesl/khypervisor/wiki/Hardware-Resources-of-Guest-Linux-on-FastModels-RTSM_VE-Cortex-A15x1
 
+    _virqmap[1].virq = 1;
+    _virqmap[1].vmid = 0;
+    _virqmap[31].virq = 31;
+    _virqmap[31].vmid = 0;
+    _virqmap[33].virq = 33;
+    _virqmap[33].vmid = 0;
+    _virqmap[16].virq = 16;
+    _virqmap[16].vmid = 0;
+    _virqmap[17].virq = 17;
+    _virqmap[17].vmid = 0;
+    _virqmap[18].virq = 18;
+    _virqmap[18].vmid = 0;
+    _virqmap[19].virq = 19;
+    _virqmap[19].vmid = 0;
     // WDT: shared driver
-    // IRQ 32
+    // IRQ 32i
     _virqmap[32].virq = 32;
     _virqmap[32].vmid = 0;
 

--- a/monitor/virqmap.c
+++ b/monitor/virqmap.c
@@ -48,7 +48,7 @@ hvmm_status_t virqmap_init(void)
     _virqmap[19].virq = 19;
     _virqmap[19].vmid = 0;
     // WDT: shared driver
-    // IRQ 32i
+    // IRQ 32
     _virqmap[32].virq = 32;
     _virqmap[32].vmid = 0;
 

--- a/monitor/virqmap.c
+++ b/monitor/virqmap.c
@@ -117,12 +117,12 @@ uint32_t virqmap_pirq(vmid_t vmid, uint32_t virq)
 }
 
 
-// vgicd_changed_istatus callback in handler_ISCENABLER
 void virqmap_vgicd_changed_istatus_callback_handler( vmid_t vmid, uint32_t istatus, uint8_t word_offset )
 {
     uint32_t cstatus;                          // changed bits only
     uint32_t minirq;
     int bit;
+    int igstatus = 0;
 
     minirq = word_offset * 32;                 /* irq range: 0~31 + word_offset * size_of_istatus_in_bits */
     cstatus = old_vgicd_status[word_offset] ^ istatus;   // find changed bits
@@ -139,17 +139,20 @@ void virqmap_vgicd_changed_istatus_callback_handler( vmid_t vmid, uint32_t istat
             /* changed bit */
             if ( istatus & (1 << bit) ) {
                 printh("[%s : %d] enabled irq num is %d\n", __FUNCTION__, __LINE__, bit + minirq);
-                gic_enable_irq(pirq);
+                //gic_enable_irq(pirq);
+                gic_test_configure_irq(pirq, GIC_INT_POLARITY_LEVEL, gic_cpumask_current(), GIC_INT_PRIORITY_DEFAULT );
             } else {
                 printh("[%s : %d] disabled irq num is %d\n",__FUNCTION__, __LINE__, bit + minirq);
                 gic_disable_irq(pirq);
             }
+            igstatus = 0;
         } else {
             printh( "WARNING: Ignoring virq %d for guest %d has no mapped pirq\n", virq, vmid );
+            istatus &= ~(1 << bit);
+            igstatus = 1;
         }
-
         cstatus &= ~(1<< bit);
     }
-
-    old_vgicd_status[word_offset] = istatus;
+    if(!igstatus)        
+        old_vgicd_status[word_offset] = istatus;
 }

--- a/monitor/vmm.c
+++ b/monitor/vmm.c
@@ -66,28 +66,53 @@ static struct memmap_desc guest_md_empty[] = {
     {       0, 0, 0, 0,  0},
 };
 
+#if defined (CFG_BOARD_ARNDALE)
+
 static struct memmap_desc guest_device_md0[] = {
     /*  label, ipa       , pa        ,       size, attr */
-    {  "uart", 0x1C090000, CFG_UART1,     0x10000, LPAED_STAGE2_MEMATTR_DM },
-    { "sp804", 0x1C110000, 0x1C110000,     0x10000, LPAED_STAGE2_MEMATTR_DM },
-    { "pwm_timer", 0x3FD10000, 0x12DD0000,     0x10000, LPAED_STAGE2_MEMATTR_DM },
+    {  "uart", 0x1C090000, 0x12C10000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
+    { "sp804", 0x1C110000, 0x1C110000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
+    { "pwm_timer", 0x3FD10000, 0x12DD0000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
     /* UNMAP {  "gicd", 0x2C001000, 0x2C001000,     0x1000, LPAED_STAGE2_MEMATTR_DM }, */
     {  "gicc", 0x2C000000 | GIC_OFFSET_GICC, CFG_GIC_BASE_PA | GIC_OFFSET_GICVI,     0x2000, LPAED_STAGE2_MEMATTR_DM },
-    {       0, 0, 0, 0,  0},
-};
-
-static struct memmap_desc guest_memory_md0[] = {
-    /* 756MB */
-    { "start", 0x00000000,          0, 0x30000000, LPAED_STAGE2_MEMATTR_NORMAL_OWT | LPAED_STAGE2_MEMATTR_NORMAL_IWT },
     {       0, 0, 0, 0,  0},
 };
 
 static struct memmap_desc guest_device_md1[] = {
-    {  "uart", 0x1C090000, CFG_UART2,     0x10000, LPAED_STAGE2_MEMATTR_DM },
-    { "sp804", 0x1C110000, 0x1C120000,     0x10000, LPAED_STAGE2_MEMATTR_DM },
-    { "pwm_timer", 0x3FD10000, 0x12DD0000,     0x10000, LPAED_STAGE2_MEMATTR_DM },
+    {  "uart", 0x1C090000, 0x12C00000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
+    { "sp804", 0x1C110000, 0x1C120000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
+    { "pwm_timer", 0x3FD10000, 0x12DD0000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
     /* UNMAP {  "gicd", 0x2C001000, 0x2C001000,     0x1000, LPAED_STAGE2_MEMATTR_DM }, */
     {  "gicc", 0x2C000000 | GIC_OFFSET_GICC, CFG_GIC_BASE_PA | GIC_OFFSET_GICVI,     0x2000, LPAED_STAGE2_MEMATTR_DM },
+    {       0, 0, 0, 0,  0},
+};
+
+#elif defined (CFG_BOARD_RTSM_VE_CA15)
+
+static struct memmap_desc guest_device_md0[] = {
+    /*  label, ipa       , pa        ,       size, attr */
+    {  "uart", 0x1C090000, 0x1C0A0000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
+    { "sp804", 0x1C110000, 0x1C110000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
+    { "pwm_timer", 0x3FD10000, 0x12DD0000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
+    /* UNMAP {  "gicd", 0x2C001000, 0x2C001000,     0x1000, LPAED_STAGE2_MEMATTR_DM }, */
+    {  "gicc", 0x2C000000 | GIC_OFFSET_GICC, CFG_GIC_BASE_PA | GIC_OFFSET_GICVI,     0x2000, LPAED_STAGE2_MEMATTR_DM },
+    {       0, 0, 0, 0,  0},
+};
+static struct memmap_desc guest_device_md1[] = {
+    {  "uart", 0x1C090000, 0x1C0B0000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
+    { "sp804", 0x1C110000, 0x1C120000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
+    { "pwm_timer", 0x3FD10000, 0x12DD0000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
+    /* UNMAP {  "gicd", 0x2C001000, 0x2C001000,     0x1000, LPAED_STAGE2_MEMATTR_DM }, */
+    {  "gicc", 0x2C000000 | GIC_OFFSET_GICC, CFG_GIC_BASE_PA | GIC_OFFSET_GICVI,     0x2000, LPAED_STAGE2_MEMATTR_DM },
+    {       0, 0, 0, 0,  0},
+};
+
+#endif
+
+
+static struct memmap_desc guest_memory_md0[] = {
+    /* 756MB */
+    { "start", 0x00000000,          0, 0x30000000, LPAED_STAGE2_MEMATTR_NORMAL_OWT | LPAED_STAGE2_MEMATTR_NORMAL_IWT },
     {       0, 0, 0, 0,  0},
 };
 
@@ -260,7 +285,6 @@ static void vmm_ttbl2_init_entries(lpaed_t *ttbl2)
         lpaed_stage2_conf_l2_table( &ttbl2[i], (uint64_t) ((uint32_t) ttbl3), 0);
         for( j = 0; j < VMM_L2_PTE_NUM; j++) {
             ttbl3[j].pt.valid = 0;
-            //printh("- ttbl3[%d]:%x\n", j, &ttbl3[j] );
         }
     }        
 

--- a/monitor/vmm.c
+++ b/monitor/vmm.c
@@ -258,7 +258,7 @@ static void vmm_ttbl2_init_entries(lpaed_t *ttbl2)
         lpaed_stage2_conf_l2_table( &ttbl2[i], (uint64_t) ((uint32_t) ttbl3), 0);
         for( j = 0; j < VMM_L2_PTE_NUM; j++) {
             ttbl3[j].pt.valid = 0;
-            printh("- ttbl3[%d]:%x\n", j, &ttbl3[j] );
+            //printh("- ttbl3[%d]:%x\n", j, &ttbl3[j] );
         }
     }        
 

--- a/monitor/vmm.c
+++ b/monitor/vmm.c
@@ -127,7 +127,7 @@ static void vmm_ttbl3_map( lpaed_t *ttbl3, uint64_t offset, uint32_t pages, uint
     int index_l3_last = 0;
 
  
-//    printh( "%s[%d]: ttbl3:%x offset:%x pte:%x pages:%d, pa:%x\n", __FUNCTION__, __LINE__, (uint32_t) ttbl3, (uint32_t) offset, &ttbl3[offset], pages, (uint32_t) pa);
+    printh( "%s[%d]: ttbl3:%x offset:%x pte:%x pages:%d, pa:%x\n", __FUNCTION__, __LINE__, (uint32_t) ttbl3, (uint32_t) offset, &ttbl3[offset], pages, (uint32_t) pa);
     /* Initialize the address spaces with 'invalid' state */
 
     index_l3 = offset;
@@ -196,11 +196,11 @@ static void vmm_ttbl2_map(lpaed_t *ttbl2, uint64_t va_offset, uint64_t pa, uint3
     int i;
 
     HVMM_TRACE_ENTER();
-//    printh( "ttbl2:%x va_offset:%x pa:%x size:%d\n", (uint32_t) ttbl2, (uint32_t) va_offset, (uint32_t) pa, size);
+    printh( "ttbl2:%x va_offset:%x pa:%x size:%d\n", (uint32_t) ttbl2, (uint32_t) va_offset, (uint32_t) pa, size);
 
     index_l2 = va_offset >> LPAE_BLOCK_L2_SHIFT;
     block_offset = va_offset & LPAE_BLOCK_L2_MASK;
-//    printh( "- index_l2:%d block_offset:%x\n", index_l2, (uint32_t) block_offset);
+    printh( "- index_l2:%d block_offset:%x\n", index_l2, (uint32_t) block_offset);
     /* head < BLOCK */
     if ( block_offset ) {
         uint64_t offset;
@@ -223,7 +223,7 @@ static void vmm_ttbl2_map(lpaed_t *ttbl2, uint64_t va_offset, uint64_t pa, uint3
     if ( size > 0 ) {
         num_blocks = size >> LPAE_BLOCK_L2_SHIFT;
         index_l2_last = index_l2 + num_blocks;
-//        printh( "- index_l2_last:%d num_blocks:%d size:%d\n", index_l2_last, (uint32_t) num_blocks, size);
+        printh( "- index_l2_last:%d num_blocks:%d size:%d\n", index_l2_last, (uint32_t) num_blocks, size);
 
         for( i = index_l2; i < index_l2_last; i++ ) {
             lpaed_stage2_enable_l2_table( &ttbl2[i] );
@@ -236,7 +236,7 @@ static void vmm_ttbl2_map(lpaed_t *ttbl2, uint64_t va_offset, uint64_t pa, uint3
     /* tail < BLOCK */
     if ( size > 0) {
         pages = size >> LPAE_PAGE_SHIFT;
-        //printh( "- pages:%d size:%d\n", pages, size);
+        printh( "- pages:%d size:%d\n", pages, size);
         if ( pages ) {
             ttbl3 = TTBL_L3(ttbl2, index_l2_last);
             vmm_ttbl3_map( ttbl3, 0, pages, pa, mattr );
@@ -254,11 +254,11 @@ static void vmm_ttbl2_init_entries(lpaed_t *ttbl2)
     lpaed_t *ttbl3;
     for( i = 0; i < VMM_L2_PTE_NUM; i++ ) {
         ttbl3 = TTBL_L3(ttbl2, i);
-        //printh("ttbl2[%d]:%x ttbl3[]:%x\n", i, &ttbl2[i], ttbl3 );
+        printh("ttbl2[%d]:%x ttbl3[]:%x\n", i, &ttbl2[i], ttbl3 );
         lpaed_stage2_conf_l2_table( &ttbl2[i], (uint64_t) ((uint32_t) ttbl3), 0);
         for( j = 0; j < VMM_L2_PTE_NUM; j++) {
             ttbl3[j].pt.valid = 0;
-            // printh("- ttbl3[%d]:%x\n", j, &ttbl3[j] );
+            printh("- ttbl3[%d]:%x\n", j, &ttbl3[j] );
         }
     }        
 
@@ -270,7 +270,7 @@ static void vmm_init_ttbl2(lpaed_t *ttbl2, struct memmap_desc *md)
 {
     int i = 0;
     HVMM_TRACE_ENTER();
-    //printh( " - ttbl2:%x\n", (uint32_t) ttbl2 );
+    printh( " - ttbl2:%x\n", (uint32_t) ttbl2 );
     if ( ((uint64_t) ( (uint32_t) ttbl2) ) & 0x0FFFULL ) {
         printh( " - error: invalid ttbl2 address alignment\n" );
     }

--- a/monitor/vmm.c
+++ b/monitor/vmm.c
@@ -68,8 +68,9 @@ static struct memmap_desc guest_md_empty[] = {
 
 static struct memmap_desc guest_device_md0[] = {
     /*  label, ipa       , pa        ,       size, attr */
-    {  "uart", 0x1C090000, CFG_UART1,     0x1000, LPAED_STAGE2_MEMATTR_DM },
-    { "sp804", 0x1C110000, 0x1C110000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
+    {  "uart", 0x1C090000, CFG_UART1,     0x10000, LPAED_STAGE2_MEMATTR_DM },
+    { "sp804", 0x1C110000, 0x1C110000,     0x10000, LPAED_STAGE2_MEMATTR_DM },
+    { "pwm_timer", 0x3FD10000, 0x12DD0000,     0x10000, LPAED_STAGE2_MEMATTR_DM },
     /* UNMAP {  "gicd", 0x2C001000, 0x2C001000,     0x1000, LPAED_STAGE2_MEMATTR_DM }, */
     {  "gicc", 0x2C000000 | GIC_OFFSET_GICC, CFG_GIC_BASE_PA | GIC_OFFSET_GICVI,     0x2000, LPAED_STAGE2_MEMATTR_DM },
     {       0, 0, 0, 0,  0},
@@ -82,8 +83,9 @@ static struct memmap_desc guest_memory_md0[] = {
 };
 
 static struct memmap_desc guest_device_md1[] = {
-    {  "uart", 0x1C090000, CFG_UART2,     0x1000, LPAED_STAGE2_MEMATTR_DM },
-    { "sp804", 0x1C110000, 0x1C120000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
+    {  "uart", 0x1C090000, CFG_UART2,     0x10000, LPAED_STAGE2_MEMATTR_DM },
+    { "sp804", 0x1C110000, 0x1C120000,     0x10000, LPAED_STAGE2_MEMATTR_DM },
+    { "pwm_timer", 0x3FD10000, 0x12DD0000,     0x10000, LPAED_STAGE2_MEMATTR_DM },
     /* UNMAP {  "gicd", 0x2C001000, 0x2C001000,     0x1000, LPAED_STAGE2_MEMATTR_DM }, */
     {  "gicc", 0x2C000000 | GIC_OFFSET_GICC, CFG_GIC_BASE_PA | GIC_OFFSET_GICVI,     0x2000, LPAED_STAGE2_MEMATTR_DM },
     {       0, 0, 0, 0,  0},

--- a/monitor/vmm.c
+++ b/monitor/vmm.c
@@ -68,10 +68,10 @@ static struct memmap_desc guest_md_empty[] = {
 
 static struct memmap_desc guest_device_md0[] = {
     /*  label, ipa       , pa        ,       size, attr */
-    {  "uart", 0x1C090000, 0x1C0A0000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
+    {  "uart", 0x1C090000, CFG_UART1,     0x1000, LPAED_STAGE2_MEMATTR_DM },
     { "sp804", 0x1C110000, 0x1C110000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
     /* UNMAP {  "gicd", 0x2C001000, 0x2C001000,     0x1000, LPAED_STAGE2_MEMATTR_DM }, */
-    {  "gicc", CFG_GIC_BASE_PA | GIC_OFFSET_GICC, CFG_GIC_BASE_PA | GIC_OFFSET_GICVI,     0x2000, LPAED_STAGE2_MEMATTR_DM },
+    {  "gicc", 0x2C000000 | GIC_OFFSET_GICC, CFG_GIC_BASE_PA | GIC_OFFSET_GICVI,     0x2000, LPAED_STAGE2_MEMATTR_DM },
     {       0, 0, 0, 0,  0},
 };
 
@@ -82,10 +82,10 @@ static struct memmap_desc guest_memory_md0[] = {
 };
 
 static struct memmap_desc guest_device_md1[] = {
-    {  "uart", 0x1C090000, 0x1C0B0000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
+    {  "uart", 0x1C090000, CFG_UART2,     0x1000, LPAED_STAGE2_MEMATTR_DM },
     { "sp804", 0x1C110000, 0x1C120000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
     /* UNMAP {  "gicd", 0x2C001000, 0x2C001000,     0x1000, LPAED_STAGE2_MEMATTR_DM }, */
-    {  "gicc", CFG_GIC_BASE_PA | GIC_OFFSET_GICC, CFG_GIC_BASE_PA | GIC_OFFSET_GICVI,     0x2000, LPAED_STAGE2_MEMATTR_DM },
+    {  "gicc", 0x2C000000 | GIC_OFFSET_GICC, CFG_GIC_BASE_PA | GIC_OFFSET_GICVI,     0x2000, LPAED_STAGE2_MEMATTR_DM },
     {       0, 0, 0, 0,  0},
 };
 
@@ -127,7 +127,7 @@ static void vmm_ttbl3_map( lpaed_t *ttbl3, uint64_t offset, uint32_t pages, uint
     int index_l3_last = 0;
 
  
-    printh( "%s[%d]: ttbl3:%x offset:%x pte:%x pages:%d, pa:%x\n", __FUNCTION__, __LINE__, (uint32_t) ttbl3, (uint32_t) offset, &ttbl3[offset], pages, (uint32_t) pa);
+//    printh( "%s[%d]: ttbl3:%x offset:%x pte:%x pages:%d, pa:%x\n", __FUNCTION__, __LINE__, (uint32_t) ttbl3, (uint32_t) offset, &ttbl3[offset], pages, (uint32_t) pa);
     /* Initialize the address spaces with 'invalid' state */
 
     index_l3 = offset;
@@ -196,11 +196,11 @@ static void vmm_ttbl2_map(lpaed_t *ttbl2, uint64_t va_offset, uint64_t pa, uint3
     int i;
 
     HVMM_TRACE_ENTER();
-    printh( "ttbl2:%x va_offset:%x pa:%x size:%d\n", (uint32_t) ttbl2, (uint32_t) va_offset, (uint32_t) pa, size);
+//    printh( "ttbl2:%x va_offset:%x pa:%x size:%d\n", (uint32_t) ttbl2, (uint32_t) va_offset, (uint32_t) pa, size);
 
     index_l2 = va_offset >> LPAE_BLOCK_L2_SHIFT;
     block_offset = va_offset & LPAE_BLOCK_L2_MASK;
-    printh( "- index_l2:%d block_offset:%x\n", index_l2, (uint32_t) block_offset);
+//    printh( "- index_l2:%d block_offset:%x\n", index_l2, (uint32_t) block_offset);
     /* head < BLOCK */
     if ( block_offset ) {
         uint64_t offset;
@@ -223,7 +223,7 @@ static void vmm_ttbl2_map(lpaed_t *ttbl2, uint64_t va_offset, uint64_t pa, uint3
     if ( size > 0 ) {
         num_blocks = size >> LPAE_BLOCK_L2_SHIFT;
         index_l2_last = index_l2 + num_blocks;
-        printh( "- index_l2_last:%d num_blocks:%d size:%d\n", index_l2_last, (uint32_t) num_blocks, size);
+//        printh( "- index_l2_last:%d num_blocks:%d size:%d\n", index_l2_last, (uint32_t) num_blocks, size);
 
         for( i = index_l2; i < index_l2_last; i++ ) {
             lpaed_stage2_enable_l2_table( &ttbl2[i] );
@@ -236,7 +236,7 @@ static void vmm_ttbl2_map(lpaed_t *ttbl2, uint64_t va_offset, uint64_t pa, uint3
     /* tail < BLOCK */
     if ( size > 0) {
         pages = size >> LPAE_PAGE_SHIFT;
-        printh( "- pages:%d size:%d\n", pages, size);
+        //printh( "- pages:%d size:%d\n", pages, size);
         if ( pages ) {
             ttbl3 = TTBL_L3(ttbl2, index_l2_last);
             vmm_ttbl3_map( ttbl3, 0, pages, pa, mattr );
@@ -254,7 +254,7 @@ static void vmm_ttbl2_init_entries(lpaed_t *ttbl2)
     lpaed_t *ttbl3;
     for( i = 0; i < VMM_L2_PTE_NUM; i++ ) {
         ttbl3 = TTBL_L3(ttbl2, i);
-        printh("ttbl2[%d]:%x ttbl3[]:%x\n", i, &ttbl2[i], ttbl3 );
+        //printh("ttbl2[%d]:%x ttbl3[]:%x\n", i, &ttbl2[i], ttbl3 );
         lpaed_stage2_conf_l2_table( &ttbl2[i], (uint64_t) ((uint32_t) ttbl3), 0);
         for( j = 0; j < VMM_L2_PTE_NUM; j++) {
             ttbl3[j].pt.valid = 0;
@@ -270,7 +270,7 @@ static void vmm_init_ttbl2(lpaed_t *ttbl2, struct memmap_desc *md)
 {
     int i = 0;
     HVMM_TRACE_ENTER();
-    printh( " - ttbl2:%x\n", (uint32_t) ttbl2 );
+    //printh( " - ttbl2:%x\n", (uint32_t) ttbl2 );
     if ( ((uint64_t) ( (uint32_t) ttbl2) ) & 0x0FFFULL ) {
         printh( " - error: invalid ttbl2 address alignment\n" );
     }

--- a/patch/u-boot_arndale.patch
+++ b/patch/u-boot_arndale.patch
@@ -1,0 +1,13 @@
+diff --git a/include/configs/arndale5250.h b/include/configs/arndale5250.h
+index 2daa3a6..2dc6595 100644
+--- a/include/configs/arndale5250.h
++++ b/include/configs/arndale5250.h
+@@ -137,7 +137,7 @@
+ /* secondary SMP pens */
+ #define CONFIG_SPL_SMP_PEN	(CONFIG_SPL_TEXT_BASE + CONFIG_SPL_MAX_SIZE - 8)
+ 
+-#define CONFIG_BOOTCOMMAND	"mmc read 40007000 451 2000; bootm 40007000"
++#define CONFIG_BOOTCOMMAND	"mmc read 0xa0000000 451 800; mmc read 0x60000000 851 400; mmc read 0x90000000 851 400; go 0xa000004c"
+ /* Miscellaneous configurable options */
+ #define CONFIG_SYS_LONGHELP		/* undef to save memory */
+ #define CONFIG_SYS_HUSH_PARSER		/* use "hush" command parser	*/


### PR DESCRIPTION
v1-arndale : run guest0/1 on arndale board
    1. uart base address uses configuration marco
    2. when run guest on arndale board, type command -- make ARNDALE=y
    3. gic ipa, that uses guest0/1, set number
    4. device/gic/vgic.c : when LR is empty, then vgic is disable
    5. make sure virtual id in list register is unique virtualid for that virtual cpu interface.
    6. bug fix : virqmap_vgicd_changed_istatus_callback_handler
         when guest 1 access not assign device, then vgicd old status must not modify.
    7. add pwm timer. now bmguest can use pwm timer. but only use on arndale board
