### PR TITLE
arndale : enable arndale linux support

### DIFF
--- a/bmguest/c_start.c
+++ b/bmguest/c_start.c
@@ -33,6 +33,10 @@
 #include "test_sp804_timer.h"
 #endif
 
+//#define TESTS_ENABLE_VDEV_SAMPLE
+//#define TESTS_ENABLE_PWM_TIMER
+//#define TESTS_ENABLE_SP804_TIMER
+
 #ifdef __MONITOR_CALL_HVC__
 #define hsvc_ping()	asm("hvc #0xFFFE")
 #define hsvc_yield()	asm("hvc #0xFFFD")
@@ -45,15 +49,14 @@
 #endif
 
 #ifndef NUM_ITERATIONS	
-#define NUM_ITERATIONS	10
+#define NUM_ITERATIONS	1000
 #endif
 
 inline void nrm_delay(void)
 {
 	volatile int i = 0;
-	for( i = 0; i < 0x00000FFF; i++);
+	for( i = 0; i < 0x0000FFFF; i++);
 }
-
 
 void nrm_loop(void) 
 {
@@ -73,14 +76,19 @@ void nrm_loop(void)
      * - Otherwise, the monitor will hang with data abort
      */
      
+#ifdef TESTS_ENABLE_VDEV_SAMPLE
     test_vdev_sample();
+#endif
     
-#ifdef ARNDALE
+#ifdef TESTS_ENABLE_PWM_TIMER
     hvmm_tests_pwm_timer();
-#else
+#endif
+
+#ifdef TESTS_ENABLE_SP804_TIMER
     /* Test the SP804 timer */
     hvmm_tests_sp804_timer();
 #endif
+
 
 	for( i = 0; i < NUM_ITERATIONS; i++ ) {
 		uart_print(GUEST_LABEL); uart_print("iteration "); uart_print_hex32( i ); uart_print( "\n\r" );

--- a/bmguest/gic.c
+++ b/bmguest/gic.c
@@ -34,7 +34,11 @@
  */
 
 /* Determined by Hypervisor's Stage2 Address Translation Table */
+#ifdef ARNDALE
+#define GIC_BASEADDR_GUEST                (0x10480000)
+#else
 #define GIC_BASEADDR_GUEST                (0x2C000000)
+#endif
 
 struct gic {
     uint32_t baseaddr;

--- a/common/include/hvmm_trace.h
+++ b/common/include/hvmm_trace.h
@@ -2,8 +2,16 @@
 #define __HVMM_TRACE_H__
 #include "uart_print.h"
 
-#define HVMM_TRACE_ENTER()	{uart_print( __FUNCTION__ );  uart_print("() - enter\n\r");}
-#define HVMM_TRACE_EXIT()	{uart_print( __FUNCTION__ );  uart_print("() - exit\n\r");}
+#ifdef DEBUG
+#define HVMM_TRACE_ENTER()  {uart_print( __FUNCTION__ );  uart_print("() - enter\n\r");}
+#define HVMM_TRACE_EXIT()   {uart_print( __FUNCTION__ );  uart_print("() - exit\n\r");}
 #define HVMM_TRACE_HEX32(label, value)      {uart_print(label); uart_print_hex32(value); uart_print("\n\r");}
+#else
+#define HVMM_TRACE_ENTER()
+#define HVMM_TRACE_EXIT()
+#define HVMM_TRACE_HEX32(label, value)
+#endif
+
 #define hyp_abort_infinite() {while(1);}
+
 #endif

--- a/monitor/devices/gic/vgic.c
+++ b/monitor/devices/gic/vgic.c
@@ -10,7 +10,7 @@
 #include <asm-arm_inline.h>
 
 /* for test, surpress traces */
-//#define __VGIC_DISABLE_TRACE__
+#define __VGIC_DISABLE_TRACE__
 #define VGIC_SIMULATE_HWVIRQ
 
 #ifdef __VGIC_DISABLE_TRACE__
@@ -311,7 +311,8 @@ hvmm_status_t vgic_injection_enable(uint8_t enable)
         }
     }
 
-	hcr = read_hcr(); uart_print( " updated hcr:"); uart_print_hex32(hcr); uart_print("\n\r");
+	hcr = read_hcr();
+	printh( " updated hcr: %x\n", hcr);
     return HVMM_STATUS_SUCCESS;
 }
 

--- a/monitor/hmain.c
+++ b/monitor/hmain.c
@@ -40,7 +40,7 @@ void hyp_main(void)
 
     /* Virtual GIC Distributor */
     printh( "tests: Registering sample vdev:'vgicd' at %x\n", CFG_GIC_BASE_PA | GIC_OFFSET_GICD);
-    vdev_gicd_init(0x2c000000 | GIC_OFFSET_GICD);
+    vdev_gicd_init(CFG_GIC_BASE_PA | GIC_OFFSET_GICD);
 
     /* Initialize PIRQ to VIRQ mapping */
     virqmap_init();

--- a/monitor/plat/exynos5250/arndale/cfg_platform.h
+++ b/monitor/plat/exynos5250/arndale/cfg_platform.h
@@ -13,3 +13,164 @@
  */
 #define CFG_GIC_BASE_PA   0x10480000
 
+#define CFG_MACHINE_NUMBER 4274 //ARNDALE
+
+#define SZ_1                0x00000001
+#define SZ_2                0x00000002
+#define SZ_4                0x00000004
+#define SZ_8                0x00000008
+#define SZ_16               0x00000010
+#define SZ_32               0x00000020
+#define SZ_64               0x00000040
+#define SZ_128              0x00000080
+#define SZ_256              0x00000100
+#define SZ_512              0x00000200
+
+#define SZ_1K               0x00000400
+#define SZ_2K               0x00000800
+#define SZ_4K               0x00001000
+#define SZ_8K               0x00002000
+#define SZ_16K              0x00004000
+#define SZ_32K              0x00008000
+#define SZ_64K              0x00010000
+#define SZ_128K             0x00020000
+#define SZ_256K             0x00040000
+#define SZ_512K             0x00080000
+
+#define SZ_1M               0x00100000
+#define SZ_2M               0x00200000
+#define SZ_4M               0x00400000
+#define SZ_8M               0x00800000
+#define SZ_16M              0x01000000
+#define SZ_32M              0x02000000
+#define SZ_64M              0x04000000
+#define SZ_128M             0x08000000
+#define SZ_256M             0x10000000
+#define SZ_512M             0x20000000
+
+#define SZ_1G               0x40000000
+#define SZ_2G               0x80000000
+
+#define CFG_GUEST0_DEVICE_MEMORY \
+{ "pl330.0", 0x11C10000, 0x11C10000, SZ_64K, LPAED_STAGE2_MEMATTR_DM },         \
+{ "pl330.1", 0x121A0000, 0x121A0000, SZ_64K, LPAED_STAGE2_MEMATTR_DM },         \
+{ "pl330.2", 0x121B0000, 0x121B0000, SZ_64K, LPAED_STAGE2_MEMATTR_DM },         \
+{ "uart.0", 0x12C00000, 0x12C00000, SZ_64K, LPAED_STAGE2_MEMATTR_DM },          \
+{ "uart.1", 0x12C10000, 0x12C10000, SZ_64K, LPAED_STAGE2_MEMATTR_DM },          \
+{ "uart.2", 0x12C20000, 0x12C20000, SZ_64K, LPAED_STAGE2_MEMATTR_DM },          \
+{ "uart.3", 0x12C30000, 0x12C30000, SZ_64K, LPAED_STAGE2_MEMATTR_DM },          \
+{ "chipid", 0x10000000, 0x10000000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },           \
+{ "syscon", 0x10050000, 0x10050000, SZ_64K, LPAED_STAGE2_MEMATTR_DM },          \
+{ "timer", 0x12DD0000, 0x12DD0000, SZ_16K, LPAED_STAGE2_MEMATTR_DM },           \
+{ "wdt", 0x101D0000, 0x101D0000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },              \
+{ "sromc", 0x12250000, 0x12250000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },            \
+{ "hsphy", 0x12130000, 0x12130000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },            \
+{ "systimer", 0x101C0000, 0x101C0000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },         \
+{ "sysram", 0x02020000, 0x02020000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },           \
+{ "cmu", 0x10010000, 0x10010000, 144 * SZ_1K, LPAED_STAGE2_MEMATTR_DM },        \
+{ "pmu", 0x10040000, 0x10040000, SZ_64K, LPAED_STAGE2_MEMATTR_DM },             \
+{ "combiner", 0x10440000, 0x10440000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },         \
+{ "gpio1", 0x11400000, 0x11400000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },            \
+{ "gpio2", 0x13400000, 0x13400000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },            \
+{ "gpio3", 0x10D10000, 0x10D10000, SZ_256, LPAED_STAGE2_MEMATTR_DM },           \
+{ "gpio4", 0x03860000, 0x03860000, SZ_256, LPAED_STAGE2_MEMATTR_DM },           \
+{ "audss", 0x03810000, 0x03810000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },            \
+{ "hsphy", 0x12130000, 0x12130000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },            \
+{ "ss_phy", 0x12100000, 0x12100000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },           \
+{ "sysram_ns", 0x0204F000, 0x0204F000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },        \
+{ "ppmu_cpu", 0x10C60000, 0x10C60000, SZ_8K, LPAED_STAGE2_MEMATTR_DM },         \
+{ "ppmu_ddr_c", 0x10C40000, 0x10C40000, SZ_8K, LPAED_STAGE2_MEMATTR_DM },       \
+{ "ppmu_ddr_r1", 0x10C50000, 0x10C50000, SZ_8K, LPAED_STAGE2_MEMATTR_DM },      \
+{ "ppmu_ddr_l", 0x10CB0000, 0x10CB0000, SZ_8K, LPAED_STAGE2_MEMATTR_DM },       \
+{ "ppmu_right0_bus", 0x13660000, 0x13660000, SZ_8K, LPAED_STAGE2_MEMATTR_DM},   \
+{ "fimc_lite0", 0x13C00000, 0x13C00000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },       \
+{ "fimc_lite1", 0x13C10000, 0x13C10000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },       \
+{ "fimc_lite2", 0x13C90000, 0x13C90000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },       \
+{ "mipi_csis0", 0x13C20000, 0x13C20000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },       \
+{ "mipi_csis1", 0x13C30000, 0x13C30000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },       \
+{ "gicc", CFG_GIC_BASE_PA | GIC_OFFSET_GICC, CFG_GIC_BASE_PA | GIC_OFFSET_GICVI,  0x2000, LPAED_STAGE2_MEMATTR_DM }
+/* UNMAP {  "gicd", 0x2C001000, 0x2C001000,     0x1000, LPAED_STAGE2_MEMATTR_DM }, */
+
+#define CFG_GUEST1_DEVICE_MEMORY \
+{ "uart", 0x1C090000, CFG_UART0, 0x10000, LPAED_STAGE2_MEMATTR_DM },        \
+{ "pwm_timer", 0x3FD10000, 0x12DD0000, 0x1000, LPAED_STAGE2_MEMATTR_DM },   \
+{ "gicc", CFG_GIC_BASE_PA | GIC_OFFSET_GICC, CFG_GIC_BASE_PA | GIC_OFFSET_GICVI,  0x2000, LPAED_STAGE2_MEMATTR_DM }
+/* UNMAP {  "gicd", 0x2C001000, 0x2C001000,     0x1000, LPAED_STAGE2_MEMATTR_DM }, */
+
+#define DECLARE_VIRQMAP(name, id, _pirq, _virq) \
+    do {                                \
+        name[_pirq].virq = _virq;         \
+        name[_pirq].vmid = id;           \
+    } while (0)
+
+#define CFG_GUEST0_VIRQMAP(name) \
+    DECLARE_VIRQMAP(name, 0, 32, 32);   \
+    DECLARE_VIRQMAP(name, 0, 33, 33);   \
+    DECLARE_VIRQMAP(name, 0, 34, 34);   \
+    DECLARE_VIRQMAP(name, 0, 35, 35);   \
+    DECLARE_VIRQMAP(name, 0, 36, 36);   \
+    DECLARE_VIRQMAP(name, 0, 37, 37);   \
+    DECLARE_VIRQMAP(name, 0, 38, 38);   \
+    DECLARE_VIRQMAP(name, 0, 39, 39);   \
+    DECLARE_VIRQMAP(name, 0, 40, 40);   \
+    DECLARE_VIRQMAP(name, 0, 41, 41);   \
+    DECLARE_VIRQMAP(name, 0, 42, 42);   \
+    DECLARE_VIRQMAP(name, 0, 43, 43);   \
+    DECLARE_VIRQMAP(name, 0, 44, 44);   \
+    DECLARE_VIRQMAP(name, 0, 45, 45);   \
+    DECLARE_VIRQMAP(name, 0, 46, 46);   \
+    DECLARE_VIRQMAP(name, 0, 47, 47);   \
+    DECLARE_VIRQMAP(name, 0, 48, 48);   \
+    DECLARE_VIRQMAP(name, 0, 49, 49);   \
+    DECLARE_VIRQMAP(name, 0, 50, 50);   \
+    DECLARE_VIRQMAP(name, 0, 51, 51);   \
+    DECLARE_VIRQMAP(name, 0, 52, 52);   \
+    DECLARE_VIRQMAP(name, 0, 53, 53);   \
+    DECLARE_VIRQMAP(name, 0, 54, 54);   \
+    DECLARE_VIRQMAP(name, 0, 55, 55);   \
+    DECLARE_VIRQMAP(name, 0, 56, 56);   \
+    DECLARE_VIRQMAP(name, 0, 57, 57);   \
+    DECLARE_VIRQMAP(name, 0, 58, 58);   \
+    DECLARE_VIRQMAP(name, 0, 59, 59);   \
+    DECLARE_VIRQMAP(name, 0, 60, 60);   \
+    DECLARE_VIRQMAP(name, 0, 61, 61);   \
+    DECLARE_VIRQMAP(name, 0, 62, 62);   \
+    DECLARE_VIRQMAP(name, 0, 63, 63);   \
+    DECLARE_VIRQMAP(name, 0, 64, 64);   \
+    DECLARE_VIRQMAP(name, 0, 65, 65);   \
+    DECLARE_VIRQMAP(name, 0, 66, 66);   \
+    DECLARE_VIRQMAP(name, 0, 67, 67);   \
+    DECLARE_VIRQMAP(name, 0, 68, 68);   \
+    DECLARE_VIRQMAP(name, 0, 69, 69);   \
+    DECLARE_VIRQMAP(name, 0, 70, 70);   \
+    DECLARE_VIRQMAP(name, 0, 71, 71);   \
+    DECLARE_VIRQMAP(name, 0, 72, 72);   \
+    DECLARE_VIRQMAP(name, 0, 73, 73);   \
+    DECLARE_VIRQMAP(name, 0, 74, 74);   \
+    DECLARE_VIRQMAP(name, 0, 75, 75);   \
+    DECLARE_VIRQMAP(name, 0, 76, 76);   \
+    DECLARE_VIRQMAP(name, 0, 77, 77);   \
+    DECLARE_VIRQMAP(name, 0, 78, 78);   \
+    DECLARE_VIRQMAP(name, 0, 79, 79);   \
+    DECLARE_VIRQMAP(name, 0, 80, 80);   \
+    DECLARE_VIRQMAP(name, 0, 81, 81);   \
+    DECLARE_VIRQMAP(name, 0, 82, 82);   \
+    DECLARE_VIRQMAP(name, 0, 83, 83);   \
+    DECLARE_VIRQMAP(name, 0, 84, 84);   \
+    DECLARE_VIRQMAP(name, 0, 85, 85);   \
+    DECLARE_VIRQMAP(name, 0, 86, 86);   \
+    DECLARE_VIRQMAP(name, 0, 87, 87);   \
+    DECLARE_VIRQMAP(name, 0, 88, 88);   \
+    DECLARE_VIRQMAP(name, 0, 89, 89);   \
+    DECLARE_VIRQMAP(name, 0, 90, 90);   \
+    DECLARE_VIRQMAP(name, 0, 91, 91);   \
+    DECLARE_VIRQMAP(name, 0, 92, 92);   \
+    DECLARE_VIRQMAP(name, 0, 93, 93);   \
+    DECLARE_VIRQMAP(name, 0, 94, 94);   \
+    DECLARE_VIRQMAP(name, 0, 95, 95);   \
+    DECLARE_VIRQMAP(name, 0, 96, 96);   \
+    DECLARE_VIRQMAP(name, 0, 97, 97);   \
+    DECLARE_VIRQMAP(name, 0, 98, 98);   \
+    DECLARE_VIRQMAP(name, 0, 99, 99);
+
+#define CFG_GUEST1_VIRQMAP(name)

--- a/monitor/plat/generic_ca15/rtsmve_ca15/cfg_platform.h
+++ b/monitor/plat/generic_ca15/rtsmve_ca15/cfg_platform.h
@@ -12,3 +12,70 @@
  */
 #define CFG_GIC_BASE_PA   0x2c000000
 
+#define CFG_MACHINE_NUMBER 2272  //RTSM
+
+#define CFG_GUEST0_DEVICE_MEMORY \
+{ "sysreg", 0x1C010000, 0x1C010000,   0x1000, LPAED_STAGE2_MEMATTR_DM },        \
+{ "sysctl", 0x1C020000, 0x1C020000,   0x1000, LPAED_STAGE2_MEMATTR_DM },        \
+{ "aaci", 0x1C040000, 0x1C040000,   0x1000, LPAED_STAGE2_MEMATTR_DM },          \
+{ "mmci", 0x1C050000, 0x1C050000,   0x1000, LPAED_STAGE2_MEMATTR_DM },          \
+{ "kmi", 0x1C060000, 0x1C060000,   0x1000, LPAED_STAGE2_MEMATTR_DM },           \
+{ "kmi2", 0x1C070000, 0x1C070000,   0x1000, LPAED_STAGE2_MEMATTR_DM },          \
+{ "v2m_serial0", 0x1C090000, 0x1C0A0000,     0x1000, LPAED_STAGE2_MEMATTR_DM }, \
+{ "v2m_serial1", 0x1C0A0000, 0x1C090000,     0x1000, LPAED_STAGE2_MEMATTR_DM }, \
+{ "v2m_serial2", 0x1C0B0000, 0x1C0B0000,     0x1000, LPAED_STAGE2_MEMATTR_DM }, \
+{ "v2m_serial3", 0x1C0C0000, 0x1C0C0000,     0x1000, LPAED_STAGE2_MEMATTR_DM }, \
+{ "wdt", 0x1C0F0000, 0x1C0F0000,   0x1000, LPAED_STAGE2_MEMATTR_DM },           \
+{ "v2m_timer01(sp804)", 0x1C110000, 0x1C110000,   0x1000, LPAED_STAGE2_MEMATTR_DM },    \
+{ "v2m_timer23", 0x1C120000, 0x1C120000,   0x1000, LPAED_STAGE2_MEMATTR_DM },           \
+{ "rtc", 0x1C170000, 0x1C170000,   0x1000, LPAED_STAGE2_MEMATTR_DM },                   \
+{ "clcd", 0x1C1F0000, 0x1C1F0000,   0x1000, LPAED_STAGE2_MEMATTR_DM },                  \
+{ "gicc", CFG_GIC_BASE_PA | GIC_OFFSET_GICC, CFG_GIC_BASE_PA | GIC_OFFSET_GICVI, 0x2000, LPAED_STAGE2_MEMATTR_DM }
+/* UNMAP {  "gicd", 0x2C001000, 0x2C001000,     0x1000, LPAED_STAGE2_MEMATTR_DM }, */
+
+#define CFG_GUEST1_DEVICE_MEMORY \
+{ "uart", 0x1C090000, 0x1C0B0000, 0x1000, LPAED_STAGE2_MEMATTR_DM },    \
+{ "sp804", 0x1C110000, 0x1C120000, 0x1000, LPAED_STAGE2_MEMATTR_DM },   \
+{ "gicc", 0x2C000000 | GIC_OFFSET_GICC, CFG_GIC_BASE_PA | GIC_OFFSET_GICVI, 0x2000, LPAED_STAGE2_MEMATTR_DM }
+/* UNMAP {  "gicd", 0x2C001000, 0x2C001000,     0x1000, LPAED_STAGE2_MEMATTR_DM }, */
+
+#define DECLARE_VIRQMAP(name, id, _pirq, _virq) \
+    do {                                \
+        name[_pirq].virq = _virq;       \
+        name[_pirq].vmid = id;          \
+    } while (0)
+
+/*
+ *  vimm-0, pirq-69, virq-69 = pwm timer driver
+ *  vimm-0, pirq-32, virq-32 = WDT: shared driver
+ *  vimm-0, pirq-34, virq-34 = SP804: shared driver
+ *  vimm-0, pirq-35, virq-35 = SP804: shared driver
+ *  vimm-0, pirq-36, virq-36 = RTC: shared driver
+ *  vimm-0, pirq-38, virq-37 = UART: dedicated driver IRQ 37 for guest 0
+ *  vimm-1, pirq-39, virq-37 = UART: dedicated driver IRQ 37 for guest 1
+ *  vimm-0, pirq-43, virq-43 = ACCI: shared driver
+ *  vimm-0, pirq-44, virq-44 = KMI: shared driver
+ *  vimm-0, pirq-45, virq-45 = KMI: shared driver
+ */
+
+#define CFG_GUEST0_VIRQMAP(name) \
+    DECLARE_VIRQMAP(name, 0, 1, 1);     \
+    DECLARE_VIRQMAP(name, 0, 31, 31);   \
+    DECLARE_VIRQMAP(name, 0, 33, 33);   \
+    DECLARE_VIRQMAP(name, 0, 16, 16);   \
+    DECLARE_VIRQMAP(name, 0, 17, 17);   \
+    DECLARE_VIRQMAP(name, 0, 18, 18);   \
+    DECLARE_VIRQMAP(name, 0, 19, 19);   \
+    DECLARE_VIRQMAP(name, 0, 69, 69);   \
+    DECLARE_VIRQMAP(name, 0, 32, 32);   \
+    DECLARE_VIRQMAP(name, 0, 34, 34);   \
+    DECLARE_VIRQMAP(name, 0, 35, 35);   \
+    DECLARE_VIRQMAP(name, 0, 36, 36);   \
+    DECLARE_VIRQMAP(name, 0, 38, 37);   \
+    DECLARE_VIRQMAP(name, 1, 39, 37);   \
+    DECLARE_VIRQMAP(name, 0, 43, 43);   \
+    DECLARE_VIRQMAP(name, 0, 44, 44);   \
+    DECLARE_VIRQMAP(name, 0, 45, 45);
+
+
+#define CFG_GUEST1_VIRQMAP(name)

--- a/monitor/print.c
+++ b/monitor/print.c
@@ -8,7 +8,7 @@ void init_print()
     format_reg_puts(&uart_print);
 }
 
-void printh(const char *format, ...)
+void printH(const char *format, ...)
 {
     va_list ap;
     va_start(ap, format);

--- a/monitor/print.h
+++ b/monitor/print.h
@@ -2,5 +2,13 @@
 #define __PRINT_H__
 
 void init_print();
-void printh(const char *format, ...);
+
+void printH(const char *format, ...);
+
+#ifdef DEBUG
+#define printh printH
+#else
+#define printh(format, args...) ((void)0)
+#endif
+
 #endif

--- a/monitor/scheduler.c
+++ b/monitor/scheduler.c
@@ -10,10 +10,13 @@ void scheduler_schedule(void)
 
 void scheduler_test_switch_to_next_guest(void *pdata){
     struct arch_regs *regs = pdata;
+#if 0 /* ignore message due to flood log message */
     uint64_t pct = read_cntpct();
     uint32_t tval = read_cnthp_tval();
+
     uart_print( "cntpct:"); uart_print_hex64(pct); uart_print("\n\r");
     uart_print( "cnth_tval:"); uart_print_hex32(tval); uart_print("\n\r");
+#endif
 
     /* Note: As of context_switchto() and context_perform_switch() are available,
        no need to test if trapped from Hyp mode.

--- a/monitor/trap.c
+++ b/monitor/trap.c
@@ -5,6 +5,7 @@
 #include "gic.h"
 #include "sched_policy.h"
 #include "trap_dabort.h"
+
 #include "print.h"
 
 /* By holding the address to the saved regs struct, 
@@ -84,11 +85,11 @@ hyp_hvc_result_t _hyp_hvc_service(struct arch_regs *regs)
 
 		_trap_hyp_saved_regs = regs;
 
-		uart_print("[hvc] _hyp_hvc_service: enter\n\r");
+		printh("[hvc] _hyp_hvc_service: enter\n\r");
 
     if ( ec == 0x12 && ((iss & 0xFFFF) == 0xFFFF) ) {
         /* Internal request to stay in hyp mode */
-        uart_print("[hvc] enter hyp\n\r");
+        printh("[hvc] enter hyp\n\r");
         context_dump_regs( regs );
         return HYP_RESULT_STAY;
     }
@@ -113,13 +114,13 @@ hyp_hvc_result_t _hyp_hvc_service(struct arch_regs *regs)
         switch( iss ) {
             case 0xFFFE:
                 /* hyp_ping */
-                uart_print("[hyp] _hyp_hvc_service:ping\n\r");
+                printh("[hyp] _hyp_hvc_service:ping\n\r");
                 context_dump_regs( regs );
                 break;
             case 0xFFFD:
                 {
                     /* hsvc_yield() */
-                    uart_print("[hyp] _hyp_hvc_service:yield\n\r");
+                    printh("[hyp] _hyp_hvc_service:yield\n\r");
                     context_dump_regs( regs );
                     context_switchto(sched_policy_determ_next());
                 }
@@ -130,16 +131,16 @@ hyp_hvc_result_t _hyp_hvc_service(struct arch_regs *regs)
                     printh( "[hyp]: prefetch abort routed to Hyp mode\n");
                 }
     
-                uart_print("[hyp] _hyp_hvc_service:unknown hsr.iss="); uart_print_hex32( iss ); uart_print("\n\r" );
-                uart_print("[hyp] hsr.ec="); uart_print_hex32( ec ); uart_print("\n\r" );
-                uart_print("[hyp] hsr="); uart_print_hex32( hsr ); uart_print("\n\r" );
+                printh("[hyp] _hyp_hvc_service:unknown hsr.iss= %x\n", iss);
+                printh("[hyp] hsr.ec= %x\n", ec);
+                printh("[hyp] hsr= %x\n", hsr);
                 context_dump_regs( regs );
                 _trap_dump_bregs();
                 hyp_abort_infinite();
                 break;
         }
     }
-    uart_print("[hyp] _hyp_hvc_service: done\n\r");
+    printh("[hyp] _hyp_hvc_service: done\n\r");
 
     context_perform_switch();
     return HYP_RESULT_ERET;

--- a/monitor/trap_dabort.c
+++ b/monitor/trap_dabort.c
@@ -2,9 +2,11 @@
 #include <armv7_p15.h>
 #include <vdev.h>
 #include <hvmm_trace.h>
-#include "print.h"
 #include "context.h"
 #include "trap_dabort.h"
+
+#define DEBUG
+#include "print.h"
 
 /*
  * ISS encoding for Data Abort exceptions taken to Hyp mode as beloww

--- a/monitor/vdev/vdev.c
+++ b/monitor/vdev/vdev.c
@@ -51,7 +51,7 @@ hvmm_status_t vdev_emulate(uint32_t fipa, uint32_t wnr, vdev_access_size_t acces
     int i = 0;
     uint32_t offset;
     uint8_t isize = 4;
-    vmid_t vmid = context_current_vmid();
+
     HVMM_TRACE_ENTER();
     if ( regs->cpsr & 0x20 ) {
         /* Thumb */
@@ -64,7 +64,7 @@ hvmm_status_t vdev_emulate(uint32_t fipa, uint32_t wnr, vdev_access_size_t acces
         offset = fipa - vdev_list[i].base;
         if ( fipa >= vdev_list[i].base && offset < vdev_list[i].size && vdev_list[i].handler != 0) {
             /* fipa is in the rage: base ~ base + size */
-            printh("vdev: found %s for fipa %x srt:%x gpr[srt]:%x write:%d vmid:%d\n", vdev_list[i].name, fipa, srt, regs->gpr[srt], wnr, vmid );
+            printh("vdev: found %s for fipa %x srt:%x gpr[srt]:%x write:%d vmid:%d\n", vdev_list[i].name, fipa, srt, regs->gpr[srt], wnr, context_current_vmid() );
             result = vdev_list[i].handler(wnr, offset, &(regs->gpr[srt]), access_size);
             if ( wnr == 0 ) {
                 printh("vdev: result:%x\n", regs->gpr[srt] );

--- a/monitor/virqmap.c
+++ b/monitor/virqmap.c
@@ -1,3 +1,4 @@
+#include <cfg_platform.h>
 #include <hyp_config.h>
 #include "virqmap.h"
 #include "print.h"
@@ -32,66 +33,8 @@ hvmm_status_t virqmap_init(void)
     }
 
     // NOTE(wonseok): referenced by https://github.com/kesl/khypervisor/wiki/Hardware-Resources-of-Guest-Linux-on-FastModels-RTSM_VE-Cortex-A15x1
-
-    // Test vgicd look bmguest/gic.c
-    _virqmap[1].virq = 1;
-    _virqmap[1].vmid = 0;
-    _virqmap[31].virq = 31;
-    _virqmap[31].vmid = 0;
-    _virqmap[33].virq = 33;
-    _virqmap[33].vmid = 0;
-    _virqmap[16].virq = 16;
-    _virqmap[16].vmid = 0;
-    _virqmap[17].virq = 17;
-    _virqmap[17].vmid = 0;
-    _virqmap[18].virq = 18;
-    _virqmap[18].vmid = 0;
-    _virqmap[19].virq = 19;
-    _virqmap[19].vmid = 0;
-
-    // pwm timer driver
-    // IRQ 69
-    _virqmap[69].virq = 69;
-    _virqmap[69].vmid = 0;
-    
-    // WDT: shared driver
-    // IRQ 32
-    _virqmap[32].virq = 32;
-    _virqmap[32].vmid = 0;
-
-    // SP804: shared driver
-    // IRQ 34, 35
-    _virqmap[34].virq = 34;
-    _virqmap[34].vmid = 0;
-    _virqmap[35].virq = 35;
-    _virqmap[35].vmid = 0;
-
-    // RTC: shared driver
-    // IRQ 36
-    _virqmap[36].virq = 36;
-    _virqmap[36].vmid = 0;
-
-    // UART: dedicated driver 
-    // IRQ 37 for guest 0
-
-    // IRQ 37 for guest 0
-    _virqmap[38].virq = 37;
-    _virqmap[38].vmid = 0;
-    // IRQ 38 for guest 1
-    _virqmap[39].virq = 37;
-    _virqmap[39].vmid = 1;
-
-    // ACCI: shared driver
-    // IRQ 43 
-    _virqmap[43].virq = 43;
-    _virqmap[43].vmid = 0; 
-
-    // KMI: shared driver
-    // IRQ 44, 45
-    _virqmap[44].virq = 44;
-    _virqmap[44].vmid = 0; 
-    _virqmap[45].virq = 45;
-    _virqmap[45].vmid = 0; 
+    CFG_GUEST0_VIRQMAP(_virqmap);
+    CFG_GUEST1_VIRQMAP(_virqmap);
 
     vgicd_set_callback_changed_istatus(&virqmap_vgicd_changed_istatus_callback_handler);
 

--- a/monitor/vmm.c
+++ b/monitor/vmm.c
@@ -66,74 +66,17 @@ static struct memmap_desc guest_md_empty[] = {
     {       0, 0, 0, 0,  0},
 };
 
-#if defined (CFG_BOARD_ARNDALE)
-
 static struct memmap_desc guest_device_md0[] = {
-    /*  label, ipa       , pa        ,       size, attr */
-    {   "sysreg", 0x1c010000, 0x1c010000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {   "sysctl", 0x1c020000, 0x1c020000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {   "aaci", 0x1c040000, 0x1c040000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {   "mmci", 0x1c050000, 0x1c050000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {   "kmi", 0x1c060000, 0x1c060000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {   "kmi2", 0x1c070000, 0x1c070000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {  "v2m_serial0", 0x1C090000, 0x12C10000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {  "v2m_serial1", 0x1C0a0000, 0x12C00000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {  "v2m_serial2", 0x1C0b0000, 0x12C20000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {  "v2m_serial3", 0x1C0c0000, 0x12C30000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {   "wdt", 0x1c0F0000, 0x1c0F0000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    /* UNMAP {  "gicd", 0x2C001000, 0x2C001000,     0x1000, LPAED_STAGE2_MEMATTR_DM }, */
-    {  "gicc", 0x2C000000 | GIC_OFFSET_GICC, CFG_GIC_BASE_PA | GIC_OFFSET_GICVI,     0x2000, LPAED_STAGE2_MEMATTR_DM },
-    {   "v2m_timer01(sp804)", 0x1c110000, 0x1c110000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {   "v2m_timer23", 0x1c120000, 0x1c120000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {   "rtc", 0x1c170000, 0x1c170000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {   "clcd", 0x1c1f0000, 0x1c1f0000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    { "pwm_timer", 0x3FD10000, 0x12DD0000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {       0, 0, 0, 0,  0},
+    /*  label, ipa, pa, size, attr */
+    CFG_GUEST0_DEVICE_MEMORY,
+    { 0, 0, 0, 0,  0},
 };
 
 static struct memmap_desc guest_device_md1[] = {
-    {  "uart", 0x1C090000, 0x12C00000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
-    { "sp804", 0x1C110000, 0x1C120000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
-    { "pwm_timer", 0x3FD10000, 0x12DD0000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
-    /* UNMAP {  "gicd", 0x2C001000, 0x2C001000,     0x1000, LPAED_STAGE2_MEMATTR_DM }, */
-    {  "gicc", 0x2C000000 | GIC_OFFSET_GICC, CFG_GIC_BASE_PA | GIC_OFFSET_GICVI,     0x2000, LPAED_STAGE2_MEMATTR_DM },
-    {       0, 0, 0, 0,  0},
+    /*  label, ipa, pa, size, attr */
+    CFG_GUEST1_DEVICE_MEMORY,
+    { 0, 0, 0, 0,  0},
 };
-
-#elif defined (CFG_BOARD_RTSM_VE_CA15)
-
-static struct memmap_desc guest_device_md0[] = {
-    /*  label, ipa       , pa        ,       size, attr */
-    {   "sysreg", 0x1c010000, 0x1c010000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {   "sysctl", 0x1c020000, 0x1c020000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {   "aaci", 0x1c040000, 0x1c040000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {   "mmci", 0x1c050000, 0x1c050000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {   "kmi", 0x1c060000, 0x1c060000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {   "kmi2", 0x1c070000, 0x1c070000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {  "v2m_serial0", 0x1C090000, 0x1C0a0000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {  "v2m_serial1", 0x1C0a0000, 0x1C090000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {  "v2m_serial2", 0x1C0b0000, 0x1C0b0000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {  "v2m_serial3", 0x1C0c0000, 0x1C0c0000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {   "wdt", 0x1c0F0000, 0x1c0F0000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    /* UNMAP {  "gicd", 0x2C001000, 0x2C001000,     0x1000, LPAED_STAGE2_MEMATTR_DM }, */
-    {  "gicc", 0x2C000000 | GIC_OFFSET_GICC, CFG_GIC_BASE_PA | GIC_OFFSET_GICVI,     0x2000, LPAED_STAGE2_MEMATTR_DM },
-    {   "v2m_timer01(sp804)", 0x1c110000, 0x1c110000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {   "v2m_timer23", 0x1c120000, 0x1c120000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {   "rtc", 0x1c170000, 0x1c170000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {   "clcd", 0x1c1f0000, 0x1c1f0000,   0x1000, LPAED_STAGE2_MEMATTR_DM },
-    {       0, 0, 0, 0,  0},
-};
-
-static struct memmap_desc guest_device_md1[] = {
-    {  "uart", 0x1C090000, 0x1C0B0000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
-    { "sp804", 0x1C110000, 0x1C120000,     0x1000, LPAED_STAGE2_MEMATTR_DM },
-    /* UNMAP {  "gicd", 0x2C001000, 0x2C001000,     0x1000, LPAED_STAGE2_MEMATTR_DM }, */
-    {  "gicc", 0x2C000000 | GIC_OFFSET_GICC, CFG_GIC_BASE_PA | GIC_OFFSET_GICVI,     0x2000, LPAED_STAGE2_MEMATTR_DM },
-    {       0, 0, 0, 0,  0},
-};
-
-#endif
-
 
 static struct memmap_desc guest_memory_md0[] = {
     /* 756MB */
@@ -458,7 +401,10 @@ hvmm_status_t vmm_set_vmid_ttbl( vmid_t vmid, lpaed_t *ttbl )
      * VTTBR.VMID = vmid
      * VTTBR.BADDR = ttbl
      */
-    vttbr = read_vttbr(); uart_print( "current vttbr:" ); uart_print_hex64(vttbr); uart_print("\n\r");
+    vttbr = read_vttbr();
+#if 0 /* ignore message due to flood log message */
+    uart_print( "current vttbr:" ); uart_print_hex64(vttbr); uart_print("\n\r");
+#endif
     vttbr &= ~(VTTBR_VMID_MASK);
     vttbr |= ((uint64_t)vmid << VTTBR_VMID_SHIFT) & VTTBR_VMID_MASK;
 
@@ -466,6 +412,9 @@ hvmm_status_t vmm_set_vmid_ttbl( vmid_t vmid, lpaed_t *ttbl )
     vttbr |= (uint32_t) ttbl & VTTBR_BADDR_MASK;
     write_vttbr(vttbr);
 
-    vttbr = read_vttbr(); uart_print( "changed vttbr:" ); uart_print_hex64(vttbr); uart_print("\n\r");
+    vttbr = read_vttbr();
+#if 0 /* ignore message due to flood log message */
+    uart_print( "changed vttbr:" ); uart_print_hex64(vttbr); uart_print("\n\r");
+#endif
     return HVMM_STATUS_SUCCESS;
 }


### PR DESCRIPTION
platform specific contents(virq, device mapping) move to cfg_platform.h
, disable flood log message due to linux loading
