### PR TITLE
mm : solved performance issue by changing write back

### DIFF
--- a/hypervisor/mm.c
+++ b/hypervisor/mm.c
@@ -160,21 +160,24 @@ static void _hmm_init(void)
      * Partition 3: 0xC0000000 ~ 0xFFFFFFFF - Monitor
      *                                      - LV2 translation table address
      */
-    _hmm_pgtable[0] = hvmm_mm_lpaed_l1_block(pa, DEV_SHARED); pa += 0x40000000;
+    _hmm_pgtable[0] = hvmm_mm_lpaed_l1_block(pa, DEV_SHARED);
+    pa += 0x40000000;
     uart_print("&_hmm_pgtable[0]:");
     uart_print_hex32((uint32_t) &_hmm_pgtable[0]);
     uart_print("\n\r");
     uart_print("lpaed:");
     uart_print_hex64(_hmm_pgtable[0].bits);
     uart_print("\n\r");
-    _hmm_pgtable[1] = hvmm_mm_lpaed_l1_block(pa, UNCACHED); pa += 0x40000000;
+    _hmm_pgtable[1] = hvmm_mm_lpaed_l1_block(pa, UNCACHED);
+    pa += 0x40000000;
     uart_print("&_hmm_pgtable[1]:");
     uart_print_hex32((uint32_t) &_hmm_pgtable[1]);
     uart_print("\n\r");
     uart_print("lpaed:");
     uart_print_hex64(_hmm_pgtable[1].bits);
     uart_print("\n\r");
-    _hmm_pgtable[2] = hvmm_mm_lpaed_l1_block(pa, UNCACHED); pa += 0x40000000;
+    _hmm_pgtable[2] = hvmm_mm_lpaed_l1_block(pa, WRITEALLOC);
+    pa += 0x40000000;
     uart_print("&_hmm_pgtable[2]:");
     uart_print_hex32((uint32_t) &_hmm_pgtable[2]);
     uart_print("\n\r");
@@ -357,8 +360,7 @@ int hvmm_mm_init(void)
     uart_print("\n\r");
 
     /* HSCTLR Enable MMU and D-cache */
-    /* hsctlr |= (SCTLR_M |SCTLR_C); */
-    hsctlr |= (SCTLR_M);
+    hsctlr |= (SCTLR_M |SCTLR_C);
 
     /* Flush PTE writes */
     asm("dsb");

--- a/hypervisor/vmm.c
+++ b/hypervisor/vmm.c
@@ -84,7 +84,7 @@ static struct memmap_desc guest_device_md1[] = {
 static struct memmap_desc guest_memory_md0[] = {
     /* 756MB */
     {"start", 0x00000000, 0, 0x30000000,
-      LPAED_STAGE2_MEMATTR_NORMAL_OWT | LPAED_STAGE2_MEMATTR_NORMAL_IWT
+     LPAED_STAGE2_MEMATTR_NORMAL_OWB | LPAED_STAGE2_MEMATTR_NORMAL_IWB
     },
     {0, 0, 0, 0,  0},
 };
@@ -92,7 +92,7 @@ static struct memmap_desc guest_memory_md0[] = {
 static struct memmap_desc guest_memory_md1[] = {
     /* 256MB */
     {"start", 0x00000000,          0, 0x10000000,
-     LPAED_STAGE2_MEMATTR_NORMAL_OWT | LPAED_STAGE2_MEMATTR_NORMAL_IWT
+     LPAED_STAGE2_MEMATTR_NORMAL_OWB | LPAED_STAGE2_MEMATTR_NORMAL_IWB
     },
     {0, 0, 0, 0,  0},
 };


### PR DESCRIPTION
Change write through to write back due to performance enhancement.
As a result, coremark benchmark score will be the same on andale port.
- native 
  Iterations/Sec   : 3529
  Iterations       : 60000
- linux on hypervisor
  Iterations/Sec   : 3529
  Iterations       : 60000
