### PR TITLE
[GUEST] Move receiving vtimer interrupt code to c_start.c

### DIFF
--- a/common/guest/core/c_start.c
+++ b/common/guest/core/c_start.c
@@ -27,6 +27,7 @@
 #include <log/uart_print.h>
 #include <gic.h>
 #include <test/tests.h>
+#include <test/test_vtimer.h>
 
 /* #define TESTS_ENABLE_VDEV_SAMPLE */
 
@@ -59,6 +60,8 @@ void nrm_loop(void)
     uart_print(GUEST_LABEL);
     uart_print("=== Starting commom start up\n\r");
     gic_init();
+    /* Enables receiving virtual timer interrupt */
+    vtimer_mask(0);
     /* We are ready to accept irqs with GIC. Enable it now */
     irq_enable();
     /* Test the sample virtual device.

--- a/common/guest/core/gic.c
+++ b/common/guest/core/gic.c
@@ -4,7 +4,6 @@
 #include <hvmm_trace.h>
 #include <a15_cp15_sysregs.h>
 #include <armv7_p15.h>
-#include <test/test_vtimer.h>
 
 #define CBAR_PERIPHBASE_MSB_MASK    0x000000FF
 
@@ -198,8 +197,6 @@ hvmm_status_t gic_init(void)
     if (result == HVMM_STATUS_SUCCESS)
         _gic.initialized = GIC_SIGNATURE_INITIALIZED;
 
-    /* enable virtual timer */
-    vtimer_mask(0);
     HVMM_TRACE_EXIT();
     return result;
 }


### PR DESCRIPTION
This patch separates virtual timer from gic.
