### PR TITLE
added comments: trap.c trap.h, removed undifinition function.

### DIFF
--- a/hypervisor/hardware/arm32ve/libhw/trap.c
+++ b/hypervisor/hardware/arm32ve/libhw/trap.c
@@ -7,21 +7,44 @@
 #include <vdev.h>
 #define DEBUG
 #include <log/print.h>
+/**\defgroup ARM
+ * <pre> ARM registers.
+ * ARM registers include 13 general purpose registers r0-r12, 1 Stack Pointer,
+ * 1 Link Register (LR), 1 Program Counter (PC).
+ *
+ */
 
+/**@brief Handles data abort exception taken in Hyp mode.
+ * This function uses current ARM registers to dump.
+ * @param regs ARM registers used by current virtual machine.
+ * \ref ARM
+ * @return Returns HVMM_STATUS_UNKNOWN_ERROR only.
+ */
 hvmm_status_t _hyp_dabort(struct arch_regs *regs)
 {
     guest_dump_regs(regs);
     hyp_abort_infinite();
     return HVMM_STATUS_UNKNOWN_ERROR;
 }
-
+/**@brief Handles IRQ exception when interrupt is occured by a device.
+ * This funcntion calls gic interrupt, context switch.
+ * @param regs ARM registers used by current virtual machine.
+ * \ref ARM
+ * @return Returns HVMM_STATUS_SUCCESS only.
+ */
 hvmm_status_t _hyp_irq(struct arch_regs *regs)
 {
     gic_interrupt(0, regs);
     guest_perform_switch(regs);
     return HVMM_STATUS_SUCCESS;
 }
-
+/**@brief Handles undefined, hypervisor, prefetch abort as unhandled exception.
+ * Also this function dumps state of the virtual machine registers.
+ * We don't support these exceptions now.
+ * @param regs ARM registers used by current virtual machine.
+ * \ref ARM
+ * @return Returns HVMM_STATUS_UNKNOWN_ERROR only.
+ */
 hvmm_status_t _hyp_unhandled(struct arch_regs *regs)
 {
     guest_dump_regs(regs);
@@ -29,12 +52,17 @@ hvmm_status_t _hyp_unhandled(struct arch_regs *regs)
 
     return HVMM_STATUS_UNKNOWN_ERROR;
 }
-
+/**@brief Indirects _hyp_hvc_service function in file.
+ * @param regs ARM registers used by current virtual machine.
+ * \ref ARM
+ * @return Returns the same result of _hyp_hvc_service() function.
+ */
 enum hyp_hvc_result _hyp_hvc(struct arch_regs *regs)
 {
     return _hyp_hvc_service(regs);
 }
-
+/**@brief Shows temporary banked registers for debugging.
+ */
 static void _trap_dump_bregs(void)
 {
     uint32_t spsr, lr, sp;
@@ -65,6 +93,34 @@ static void _trap_dump_bregs(void)
  * END OF HSR DESCRIPTION FROM ARM DDI0406_C ARCHITECTURE MANUAL
  */
 
+/**@brief Handles the HSR which holds syndrome information for any synchronous
+ * exception taken to Hyp mode. Compared with the reporting of exceptions
+ * taken to PL1 modes.
+ * <pre> Exception class
+ *     Unknown reason
+ *     Trapped WFI or WFE instruction
+ *     Trapped MCR or MRC access to CP15
+ *     Trapped MCRR or MRRC access to CP15
+ *     Trapped MCR or MRC access to CP14
+ *     Trapped LDC or STC access to CP14
+ *     HCPTR-trapped access to CP0-CP13
+ *     Trapped MRC or VMRS access to CP10, for ID group traps
+ *     Trapped BXJ instruction
+ *     Trapped MRRC access to CP14
+ *     Supervisor Call exception routed to Hyp mode
+ *     Hypervisor Call
+ *     Trapped SMC instruction
+ *     Prefetch Abort routed to Hyp mode
+ *     Prefetch Abort taken from Hyp mode
+ *     Data Abort routed to Hyp mode
+ *     Data Abort taken from Hyp mode
+ *</pre>
+ * @param regs ARM registers used by current virtual machine.
+ * \ref ARM
+ * @return Returns the result of exception using HSR.
+ * When result is HYP_RESULT_STAY, Current mode will be stay in hypervisor mode,
+ * Otherwise it will revert to previous routine.
+ */
 enum hyp_hvc_result _hyp_hvc_service(struct arch_regs *regs)
 {
     int32_t vdev_num = -1;

--- a/hypervisor/hardware/arm32ve/libhw/trap.h
+++ b/hypervisor/hardware/arm32ve/libhw/trap.h
@@ -93,7 +93,11 @@
 #define HPFAR_FIPA_PAGE_MASK                0x00000FFF
 #define HPFAR_FIPA_PAGE_SHIFT               12
 
-hvmm_status_t trap_hvc_dabort(unsigned int iss, struct arch_regs *regs);
+/**@brief Handles HSR which holds syndrome information for any synchronous
+ *  exception taken to Hyp mode.
+ * @param regs ARM registers used by current virtual machine.
+ * @return Returns the result of exception using HSR.
+ */
 enum hyp_hvc_result _hyp_hvc_service(struct arch_regs *regs);
 
 #endif


### PR DESCRIPTION
Added comments for doxygen style in trap.[ch].

Removed function : hvmm_status_t trap_hvc_dabort(unsigned int iss, struct arch_regs *regs); in trap.h
