### PR TITLE
Removed unnecessary function, Added commnets trap.[ch]

### DIFF
--- a/hypervisor/hardware/arm32ve/libhw/trap.c
+++ b/hypervisor/hardware/arm32ve/libhw/trap.c
@@ -26,7 +26,6 @@ hvmm_status_t _hyp_unhandled(struct arch_regs *regs)
 {
     guest_dump_regs(regs);
     hyp_abort_infinite();
-
     return HVMM_STATUS_UNKNOWN_ERROR;
 }
 

--- a/hypervisor/hardware/arm32ve/libhw/trap.h
+++ b/hypervisor/hardware/arm32ve/libhw/trap.h
@@ -93,6 +93,10 @@
 #define HPFAR_FIPA_PAGE_MASK                0x00000FFF
 #define HPFAR_FIPA_PAGE_SHIFT               12
 
+/**@brief Handles every exceptions taken from a mode other than Hyp mode.
+ * @param regs ARM registers for current virtual machine.
+ * @return Returns the result of exception using HSR.
+ */
 enum hyp_hvc_result _hyp_hvc_service(struct arch_regs *regs);
 
 #endif

--- a/hypervisor/hardware/arm32ve/libhw/trap.h
+++ b/hypervisor/hardware/arm32ve/libhw/trap.h
@@ -93,7 +93,6 @@
 #define HPFAR_FIPA_PAGE_MASK                0x00000FFF
 #define HPFAR_FIPA_PAGE_SHIFT               12
 
-hvmm_status_t trap_hvc_dabort(unsigned int iss, struct arch_regs *regs);
 enum hyp_hvc_result _hyp_hvc_service(struct arch_regs *regs);
 
 #endif


### PR DESCRIPTION
Removed unnecessary function : trap_hvc_dabort() in trap.h
Removed empty line in function : trap.c
Added comments as doxygen style : trap.[ch]
