### PR TITLE
Support vexpress

### DIFF
--- a/platform-device/cortex_a15x2_rtsm/Makefile
+++ b/platform-device/cortex_a15x2_rtsm/Makefile
@@ -102,6 +102,7 @@ clean distclean:
 
 $(SEMIIMG): $(OBJS) modelsemi.lds
 	$(LD) -o $@ $(OBJS) --script=modelsemi.lds
+	$(OBJCOPY) -O binary $(SEMIIMG) $(HYPBIN)
 
 $(HYPBIN): $(SEMIIMG)
 	$(OBJCOPY) -O binary $(SEMIIMG) $(HYPBIN)

--- a/platform-device/cortex_a15x2_rtsm/README.md
+++ b/platform-device/cortex_a15x2_rtsm/README.md
@@ -28,6 +28,8 @@ $ git submodule update
 $ ./scripts/apply_patch.sh
 </pre>
 
+# How to build RTSM support hypervisor
+
 # How to test bmguest + bmguest
 
 ## Make a build in one step continuous integration
@@ -35,7 +37,7 @@ Go to "Testing bmguest on RTSM"
 this section, if you done this process first.
 <pre>
 $ cd khypervisor
-$ source platform-device/cortex_a15x2_rtsm/build/bmguest_bmguest.sh
+$ source platform-device/cortex_a15x2_rtsm/build/rtsm/bmguest_bmguest.sh
 $ make
 </pre>
 
@@ -63,6 +65,8 @@ $ cp guestloader.bin ../../guestimages/guest1.bin
 ## Building the k-hypervisor
 <pre>
 $ cd khypervisor/platform-device/cortex_a15x2_rtsm
+$ cp patch/rtsm/model.lds.S ./
+$ cp patch/rtsm/cfg_platform.h ./config/
 $ make
 </pre>
 
@@ -88,7 +92,7 @@ Go to "Testing bmguest+linuxguest on RTSM"
 this section, if you done this process first.
 <pre>
 $ cd khypervisor
-$ source platform-device/cortex_a15x2_rtsm/build/linux_bmguest.sh
+$ source platform-device/cortex_a15x2_rtsm/build/rtsm/linux_bmguest.sh
 $ make
 </pre>
 
@@ -132,6 +136,8 @@ $ cp guestloader.bin ../../guestimages/guest1.bin
 ## Building the k-hypervisor
 <pre>
 $ cd platform-device/cortex_a15x2_rtsm
+$ cp patch/rtsm/model.lds.S ./
+$ cp patch/rtsm/cfg_platform.h ./config/
 $ make
 </pre>
 
@@ -149,3 +155,157 @@ RTSM_A15-A7x14_VE/models/Linux64_GCC-4.1/RTSM_VE_Cortex-A15x1-A7x1 --cadi-server
 ARM/FastModelsTools_8.2/bin/maxview
 </pre>
  4. load hvc-man-switch.axf
+
+# How to build Vexpress support hypervisor
+
+# How to test bmguest + bmguest
+
+## Make a build in one step continuous integration
+Go to "Testing bmguest on Vexpress"
+this section, if you done this process first.
+<pre>
+$ cd khypervisor
+$ source platform-device/cortex_a15x2_rtsm/build/vexpress/bmguest_bmguest.sh
+$ make
+</pre>
+
+## Building the bmguest
+<pre>
+$ cd platform-device/cortex_a15x2_rtsm/guestos/bmguest/
+$ make
+</pre>
+
+## Building the guest loader
+1. Copy guest image to guestimages directory
+<pre>
+$ cd khypervisor/platform-device/cortex_a15x2_rtsm
+$ cp ./guestos/bmguest/bmguest.bin ./guestimages/bmguest.bin
+</pre>
+2. Build guestloader for bmguest
+<pre>
+$ cd khypervisor/platform-device/cortex_a15x2_rtsm/guestos/guestloader
+$ make
+$ cp guestloader.bin ../../guestimages/guest0.bin
+$ cp guestloader.bin ../../guestimages/guest1.bin
+</pre>
+</pre>
+
+## Building the k-hypervisor
+<pre>
+$ cd khypervisor/platform-device/cortex_a15x2_rtsm
+$ cp patch/vexpress/model.lds.S ./
+$ cp patch/vexpress/cfg_platform.h ./config/
+$ make
+</pre>
+
+## Building the u-boot
+<pre>
+$ cd khypervisor/platform-device/cortex_a15x2_rtsm/u-boot-native
+$ cp ../patch/vexpress/vexpress_ca15_tc2_bm.h \
+$ ./include/configs/vexpress_ca15_tc2.h
+$ make vexpress_ca15_tc2 CROSS_COMPILE=arm-none-eabi-
+</pre>
+
+## Testing bmguest on Vexpress
+1. Copy hypervisor, guest images, u-boot binary files
+<pre>
+$ cd khypervisor/platform-device/cortex_a15x2_rtsm
+$ cp hvc-man-switch.bin /media/VEMSD/SOFTWARE/TC2/hvc.bin
+$ cp guestimages/guest0.bin /media/VEMSD/SOFTWARE/TC2/guest0.bin
+$ cp guestimages/guest1.bin /media/VEMSD/SOFTWARE/TC2/guest1.bin
+$ cp u-boot-native/u-boot.bin /media/VEMSD/SOFTWARE/u-boot.bin
+$ eject VEMSD
+</pre>
+2. Run minicom setting - baudrate 38400, 8N1
+<pre>
+$ sudo minicom -s
+</pre>
+ 3. Run vexpress
+<pre>
+$ reboot
+$ flash run u-boot
+</pre>
+
+# How to test bmguset + linux guest
+
+## Make a build in one step continuous integration
+Go to "Testing bmguest+linuxguest on Vexpress"
+this section, if you done this process first.
+<pre>
+$ cd khypervisor
+$ source platform-device/cortex_a15x2_rtsm/build/vexpress/linux_bmguest.sh
+$ make
+</pre>
+
+## Building the bmguest
+<pre>
+$ cd platform-device/cortex_a15x2_rtsm/guestos/bmguest/
+$ make
+</pre>
+
+## Building the linux guset
+1. Building linux guest
+<pre>
+$ cd khypervisor/platform-device/cortex_a15x2_rtsm/guestos/linux
+$ cp ../../linuxguest/fs.cpio .
+$ cp ../../linuxguest/host-a15.dtb .
+$ make ARCH=arm vexpress_minhw_defconfig
+$ make CROSS_COMPILE=arm-linux-gnueabihf- ARCH=arm -j8
+$ cat host-a15.dtb >> arch/arm/boot/zImage
+</pre>
+
+## Build guest loader
+1. Copy guest image to guestimages directory
+<pre>
+$ cd khypervisor/platform-device/cortex_a15x2_rtsm
+$ cp ./guestos/linux/arch/arm/boot/zImage ./guestimages/zImage
+$ cp ./guestos/bmguest/bmguest.bin ./guestimages/bmguest.bin
+</pre>
+2. Build guestloader for linux guest
+<pre>
+$ cd khypervisor/platform-device/cortex_a15x2_rtsm/guestos/guestloader
+$ make LINUX=y
+$ cp guestloader.bin ../../guestimages/guest0.bin
+</pre>
+3. Build guestloader for bmguest
+<pre>
+$ cd khypervisor/platform-device/cortex_a15x2_rtsm/guestos/guestloader
+$ make
+$ cp guestloader.bin ../../guestimages/guest1.bin
+</pre>
+
+## Building the k-hypervisor
+<pre>
+$ cd platform-device/cortex_a15x2_rtsm
+$ cp patch/vexpress/model.lds.S ./
+$ cp patch/vexpress/cfg_platform.h ./config/
+$ make
+</pre>
+
+## Building the u-boot
+<pre>
+$ cd khypervisor/platform-device/cortex_a15x2_rtsm/u-boot-native
+$ cp ../patch/vexpress/vexpress_ca15_tc2_linux.h \
+$ ./include/configs/vexpress_ca15_tc2.h
+$ make vexpress_ca15_tc2 CROSS_COMPILE=arm-none-eabi-
+</pre>
+
+## Testing bmguest on Vexpress
+1. Copy hypervisor, guest images, u-boot binary files
+<pre>
+$ cd khypervisor/platform-device/cortex_a15x2_rtsm
+$ cp hvc-man-switch.bin /media/VEMSD/SOFTWARE/TC2/hvc.bin
+$ cp guestimages/guest0.bin /media/VEMSD/SOFTWARE/TC2/guest0.bin
+$ cp guestimages/guest1.bin /media/VEMSD/SOFTWARE/TC2/guest1.bin
+$ cp u-boot-native/u-boot.bin /media/VEMSD/SOFTWARE/u-boot.bin
+$ eject VEMSD
+</pre>
+2. Run minicom setting - baudrate 38400, 8N1
+<pre>
+$ sudo minicom -s
+</pre>
+ 3. Run vexpress
+<pre>
+$ reboot
+$ flash run u-boot
+</pre>

--- a/platform-device/cortex_a15x2_rtsm/build/rtsm/bmguest_bmguest.sh
+++ b/platform-device/cortex_a15x2_rtsm/build/rtsm/bmguest_bmguest.sh
@@ -6,6 +6,8 @@ export GUEST_COUNT=2
 
 export HYPERVISOR_BIN="hvc-man-switch.axf"
 export HYPERVISOR_BUILD_SCRIPT="make clean && \
+cp patch/rtsm/model.lds.S ./ && \
+cp patch/rtsm/cfg_platform.h ./config/ && \
 make"
 export HYPERVISOR_CLEAN_SCRIPT="make clean"
 

--- a/platform-device/cortex_a15x2_rtsm/build/rtsm/linux_bmguest.sh
+++ b/platform-device/cortex_a15x2_rtsm/build/rtsm/linux_bmguest.sh
@@ -1,0 +1,47 @@
+#for bmguest + linux
+
+export TARGET_PRODUCT="cortex_a15x2_rtsm"
+
+export GUEST_COUNT=2
+
+export HYPERVISOR_BIN="hvc-man-switch.axf"
+export HYPERVISOR_BUILD_SCRIPT="make clean && \
+cp patch/rtsm/model.lds.S ./ && \
+cp patch/rtsm/cfg_platform.h ./config/ && \
+make"
+export HYPERVISOR_CLEAN_SCRIPT="make clean"
+
+export UBOOT_DIR=""
+export UBOOT=""
+export UBOOT_BUILD_SCRIPT=""
+export UBOOT_CLEAN_SCRIPT=""
+
+export ZIMAGE_BIN="zImage"
+export BMGUEST_BIN="bmguest.bin"
+export GUEST0_DIR="guestos/guestloader"
+export GUEST0_BIN="guestloader.bin"
+export GUEST0_BUILD_SCRIPT="cd ../linux && \
+make ARCH=arm vexpress_minhw_defconfig && \
+cp -a ../../linuxguest/fs.cpio . && \
+cp -a ../../linuxguest/host-a15.dtb . && \
+make CROSS_COMPILE=arm-linux-gnueabihf- ARCH=arm -j8 && \
+cat host-a15.dtb >> arch/arm/boot/zImage && \
+cp arch/arm/boot/zImage ../../guestimages/ && \
+cd ../../$GUEST0_DIR && \
+make clean && \
+make LINUX=y"
+export GUEST0_CLEAN_SCRIPT="make clean"
+
+export GUEST1_DIR="guestos/guestloader"
+export GUEST1_BIN="guestloader.bin"
+export GUEST1_BUILD_SCRIPT="cd ../bmguest/ && \
+make clean && \
+make && \
+cp $BMGUEST_BIN ../../guestimages/ && \
+cd ../../$GUEST1_DIR && \
+make clean && \
+make"
+export GUEST1_CLEAN_SCRIPT="make clean"
+
+export GUEST_IMAGE_DIR="guestimages"
+export CI_BUILD_DIR="bmguest_linux"

--- a/platform-device/cortex_a15x2_rtsm/build/vexpress/bmguest_bmguest.sh
+++ b/platform-device/cortex_a15x2_rtsm/build/vexpress/bmguest_bmguest.sh
@@ -1,33 +1,34 @@
-#for bmguest + linux
+#for bmguest + bmguest
 
+#export TARGET_PRODUCT="cortex_a15x2_a7x3_vexpress"
 export TARGET_PRODUCT="cortex_a15x2_rtsm"
 
 export GUEST_COUNT=2
 
 export HYPERVISOR_BIN="hvc-man-switch.axf"
 export HYPERVISOR_BUILD_SCRIPT="make clean && \
+cp patch/vexpress/model.lds.S ./ && \
+cp patch/vexpress/cfg_platform.h ./config/ && \
 make"
 export HYPERVISOR_CLEAN_SCRIPT="make clean"
 
-export UBOOT_DIR=""
-export UBOOT=""
-export UBOOT_BUILD_SCRIPT=""
-export UBOOT_CLEAN_SCRIPT=""
+export UBOOT_DIR="u-boot-native"
+export UBOOT="u-boot.bin"
+export UBOOT_BUILD_SCRIPT="cp ../patch/vexpress/vexpress_ca15_tc2_bm.h \
+./include/configs/vexpress_ca15_tc2.h && \
+make vexpress_ca15_tc2 CROSS_COMPILE=arm-none-eabi-"
+export UBOOT_CLEAN_SCRIPT="make clean"
 
-export ZIMAGE_BIN="zImage"
 export BMGUEST_BIN="bmguest.bin"
 export GUEST0_DIR="guestos/guestloader"
 export GUEST0_BIN="guestloader.bin"
-export GUEST0_BUILD_SCRIPT="cd ../linux && \
-make ARCH=arm vexpress_minhw_defconfig && \
-cp -a ../../linuxguest/fs.cpio . && \
-cp -a ../../linuxguest/host-a15.dtb . && \
-make CROSS_COMPILE=arm-linux-gnueabihf- ARCH=arm -j8 && \
-cat host-a15.dtb >> arch/arm/boot/zImage && \
-cp arch/arm/boot/zImage ../../guestimages/ && \
+export GUEST0_BUILD_SCRIPT="cd ../bmguest/ && \
+make clean && \
+make && \
+cp $BMGUEST_BIN ../../guestimages/ && \
 cd ../../$GUEST0_DIR && \
 make clean && \
-make LINUX=y"
+make"
 export GUEST0_CLEAN_SCRIPT="make clean"
 
 export GUEST1_DIR="guestos/guestloader"
@@ -42,4 +43,4 @@ make"
 export GUEST1_CLEAN_SCRIPT="make clean"
 
 export GUEST_IMAGE_DIR="guestimages"
-export CI_BUILD_DIR="bmguest_linux"
+export CI_BUILD_DIR="bmguest_bmguest"

--- a/platform-device/cortex_a15x2_rtsm/build/vexpress/linux_bmguest.sh
+++ b/platform-device/cortex_a15x2_rtsm/build/vexpress/linux_bmguest.sh
@@ -1,0 +1,50 @@
+#for bmguest + linux
+
+#export TARGET_PRODUCT="cortex_a15x2_a7x3_vexpress"
+export TARGET_PRODUCT="cortex_a15x2_rtsm"
+
+export GUEST_COUNT=2
+
+export HYPERVISOR_BIN="hvc-man-switch.axf"
+export HYPERVISOR_BUILD_SCRIPT="make clean && \
+cp patch/vexpress/model.lds.S ./ && \
+cp patch/vexpress/cfg_platform.h ./config/ && \
+make"
+export HYPERVISOR_CLEAN_SCRIPT="make clean"
+
+export UBOOT_DIR="u-boot-native"
+export UBOOT="u-boot.bin"
+export UBOOT_BUILD_SCRIPT="cp ../patch/vexpress/vexpress_ca15_tc2_linux.h \
+./include/configs/vexpress_ca15_tc2.h && \
+make vexpress_ca15_tc2 CROSS_COMPILE=arm-none-eabi-"
+export UBOOT_CLEAN_SCRIPT="make clean"
+
+export ZIMAGE_BIN="zImage"
+export BMGUEST_BIN="bmguest.bin"
+export GUEST0_DIR="guestos/guestloader"
+export GUEST0_BIN="guestloader.bin"
+export GUEST0_BUILD_SCRIPT="cd ../linux && \
+make ARCH=arm vexpress_minhw_defconfig && \
+cp -a ../../linuxguest/fs.cpio . && \
+cp -a ../../linuxguest/host-a15.dtb . && \
+make CROSS_COMPILE=arm-linux-gnueabihf- ARCH=arm -j8 && \
+cat host-a15.dtb >> arch/arm/boot/zImage && \
+cp arch/arm/boot/zImage ../../guestimages/ && \
+cd ../../$GUEST0_DIR && \
+make clean && \
+make LINUX=y"
+export GUEST0_CLEAN_SCRIPT="make clean"
+
+export GUEST1_DIR="guestos/guestloader"
+export GUEST1_BIN="guestloader.bin"
+export GUEST1_BUILD_SCRIPT="cd ../bmguest/ && \
+make clean && \
+make && \
+cp $BMGUEST_BIN ../../guestimages/ && \
+cd ../../$GUEST1_DIR && \
+make clean && \
+make"
+export GUEST1_CLEAN_SCRIPT="make clean"
+
+export GUEST_IMAGE_DIR="guestimages"
+export CI_BUILD_DIR="bmguest_linux"

--- a/platform-device/cortex_a15x2_rtsm/drivers/uart/uart_print.c
+++ b/platform-device/cortex_a15x2_rtsm/drivers/uart/uart_print.c
@@ -12,14 +12,15 @@
 
 void uart_print(const char *str)
 {
-    volatile char *pUART = (char *) UART0_BASE;
     while (*str) {
-        *pUART = *str++;
+        uart_putc(*str++);
     }
 }
 
 void uart_putc(const char c)
 {
+    while (*((uint32_t *)(UART0_BASE + 0x18)) & 0x20)
+        ;
     volatile char *pUART = (char *) UART0_BASE;
     *pUART = c;
 }

--- a/platform-device/cortex_a15x2_rtsm/guestos/bmguest/Makefile
+++ b/platform-device/cortex_a15x2_rtsm/guestos/bmguest/Makefile
@@ -110,7 +110,7 @@ boot.o: boot.S
 	$(CC) $(CPPFLAGS) $(GUESTCONFIGS) -DKCMD='$(KCMD)' -c -o $@ $<
 
 %.o: %.c
-	$(CC) $(CPPFLAGS) $(GUESTCONFIGS) -O2 -ffreestanding -I.  -c -o $@ $<
+	$(CC) $(CPPFLAGS) $(GUESTCONFIGS) -O0 -ffreestanding -I.  -c -o $@ $<
 
 model.lds: $(LD_SCRIPT) Makefile
 	$(CC) $(CPPFLAGS) $(GUESTCONFIGS) -E -P -C -o $@ $<

--- a/platform-device/cortex_a15x2_rtsm/guestos/bmguest/drivers/uart.c
+++ b/platform-device/cortex_a15x2_rtsm/guestos/bmguest/drivers/uart.c
@@ -1,6 +1,6 @@
 /* UART Base Address determined by Hypervisor's Stage 2 Translation Table */
 
-#define UART_BASE       ((volatile unsigned int *) 0x1C090000)
+#define UART_BASE       (0x1C090000)
 
 static char _dummy_byte;
 
@@ -18,13 +18,14 @@ void uart_init(void)
 
 void uart_print(char *str)
 {
-    char *pUART = (char *) UART_BASE;
     while (*str)
-        *pUART = *str++;
+        uart_putc(*str++);
 }
 
 void uart_putc(char c)
 {
+    while (*((unsigned char *)(UART_BASE + 0x18)) & 0x20)
+        ;
     volatile char *pUART = (char *) UART_BASE;
     *pUART = c;
 }

--- a/platform-device/cortex_a15x2_rtsm/guestos/guestloader/drivers/uart.c
+++ b/platform-device/cortex_a15x2_rtsm/guestos/guestloader/drivers/uart.c
@@ -1,5 +1,7 @@
 /* UART Base Address determined by Hypervisor's Stage 2 Translation Table */
-#define UART_BASE       ((volatile unsigned int *) 0x1C090000)
+#define UART_BASE       (0x1C090000)
+#define UART_INCLK 24000000
+#define UART_BAUD  38400
 void uart_print(char *str)
 {
     char *pUART = (char *) UART_BASE;
@@ -25,4 +27,61 @@ void uart_print_hex32(unsigned int v)
             c += 'A' - 10;
         uart_putc((char) c);
     }
+}
+
+#define UART_CR 0x30
+#define UART_IBRD 0x24
+#define UART_FBRD 0x28
+
+#define UART_LCR_H_WLEN_8 (3 << 5)
+#define UART_LCR_H_FEN (1 << 4)
+#define UART_LCR_H 0x2c
+
+#define UART_CR_UARTEN (1 << 0)
+#define UART_CR_TXE (1 << 8)
+#define UART_CR_RXE (1 << 9)
+
+void uart_init(void)
+{
+	unsigned int base;
+	unsigned int baudrate;
+	unsigned int input_clock;
+
+    unsigned int divider;
+    unsigned int temp;
+    unsigned int remainder;
+    unsigned int fraction;
+
+    base = UART_BASE;
+    baudrate = UART_BAUD;
+    input_clock = UART_INCLK;
+
+    /* First, disable everything */
+	(*(volatile unsigned int *)(base + UART_CR)) = 0x0;
+
+    /*
+     * Set baud rate
+     *
+     * IBRD = UART_CLK / (16 * BAUD_RATE)
+     * FBRD = RND((64 * MOD(UART_CLK,(16 * BAUD_RATE)))
+     *    / (16 * BAUD_RATE))
+     */
+    temp = 16 * baudrate;
+    divider = input_clock / temp;
+    remainder = input_clock % temp;
+    temp = (8 * remainder) / baudrate;
+    fraction = (temp >> 1) + (temp & 1);
+
+	(*(volatile unsigned int *)(base + UART_IBRD)) = divider;
+	(*(volatile unsigned char *)(base + UART_FBRD)) = fraction;
+
+    /* Set the UART to be 8 bits, 1 stop bit,
+     * no parity, fifo enabled
+     */
+	(*(volatile unsigned char*)(base + UART_LCR_H))
+		= (UART_LCR_H_WLEN_8 | UART_LCR_H_FEN);
+
+    /* Finally, enable the UART */
+	(*(volatile unsigned int*)(base + UART_CR))
+		= (UART_CR_UARTEN | UART_CR_TXE | UART_CR_RXE);
 }

--- a/platform-device/cortex_a15x2_rtsm/guestos/guestloader/main.c
+++ b/platform-device/cortex_a15x2_rtsm/guestos/guestloader/main.c
@@ -29,6 +29,7 @@ static void load_guest(uint32_t type)
 }
 void main(void)
 {
+    uart_init();
     uart_print("\n\r=== starting guestloader.\n\r");
     load_guest(GUEST_TYPE);
 }

--- a/platform-device/cortex_a15x2_rtsm/patch/rtsm/cfg_platform.h
+++ b/platform-device/cortex_a15x2_rtsm/patch/rtsm/cfg_platform.h
@@ -1,0 +1,86 @@
+/*
+ *  BOARD param
+ */
+#define CFG_BOARD_RTSM_VE_CA15
+#define CFG_GENERIC_CA15
+#define CFG_CNTFRQ          100000000
+#define CFG_UART2         0x1C0B0000
+#define CFG_UART1         0x1C0A0000
+#define CFG_UART0         0x1C090000
+/*
+ *  SOC param
+ */
+#define CFG_GIC_BASE_PA   0x2c000000
+
+#define CFG_MACHINE_NUMBER 2272
+
+#define SZ_1                0x00000001
+#define SZ_2                0x00000002
+#define SZ_4                0x00000004
+#define SZ_8                0x00000008
+#define SZ_16               0x00000010
+#define SZ_32               0x00000020
+#define SZ_64               0x00000040
+#define SZ_128              0x00000080
+#define SZ_256              0x00000100
+#define SZ_512              0x00000200
+
+#define SZ_1K               0x00000400
+#define SZ_2K               0x00000800
+#define SZ_4K               0x00001000
+#define SZ_8K               0x00002000
+#define SZ_16K              0x00004000
+#define SZ_32K              0x00008000
+#define SZ_64K              0x00010000
+#define SZ_128K             0x00020000
+#define SZ_256K             0x00040000
+#define SZ_512K             0x00080000
+
+#define SZ_1M               0x00100000
+#define SZ_2M               0x00200000
+#define SZ_4M               0x00400000
+#define SZ_8M               0x00800000
+#define SZ_16M              0x01000000
+#define SZ_32M              0x02000000
+#define SZ_64M              0x04000000
+#define SZ_128M             0x08000000
+#define SZ_256M             0x10000000
+#define SZ_512M             0x20000000
+
+#define SZ_1G               0x40000000
+#define SZ_2G               0x80000000
+/**
+ * label, ipa, pa, size, attr
+ */
+#define CFG_GUEST0_DEVICE_MEMORY \
+{ \
+{ "sysreg", 0x1C010000, 0x1C010000, SZ_4K, LPAED_STAGE2_MEMATTR_DM }, \
+{ "sysctl", 0x1C020000, 0x1C020000, SZ_4K, LPAED_STAGE2_MEMATTR_DM }, \
+{ "aaci", 0x1C040000, 0x1C040000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },   \
+{ "mmci", 0x1C050000, 0x1C050000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },   \
+{ "kmi", 0x1C060000, 0x1C060000,  SZ_4K, LPAED_STAGE2_MEMATTR_DM },   \
+{ "kmi2", 0x1C070000, 0x1C070000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },   \
+{ "v2m_serial0", 0x1C090000, 0x1C0A0000, SZ_4K, LPAED_STAGE2_MEMATTR_DM }, \
+{ "v2m_serial1", 0x1C0A0000, 0x1C090000, SZ_4K, LPAED_STAGE2_MEMATTR_DM }, \
+{ "v2m_serial2", 0x1C0B0000, 0x1C0B0000, SZ_4K, LPAED_STAGE2_MEMATTR_DM }, \
+{ "v2m_serial3", 0x1C0C0000, 0x1C0C0000, SZ_4K, LPAED_STAGE2_MEMATTR_DM }, \
+{ "wdt", 0x1C0F0000, 0x1C0F0000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },         \
+{ "v2m_timer01(sp804)", 0x1C110000, 0x1C110000, SZ_4K, \
+        LPAED_STAGE2_MEMATTR_DM }, \
+{ "v2m_timer23", 0x1C120000, 0x1C120000, SZ_4K, LPAED_STAGE2_MEMATTR_DM }, \
+{ "rtc", 0x1C170000, 0x1C170000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },         \
+{ "clcd", 0x1C1F0000, 0x1C1F0000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },        \
+{ "gicc", CFG_GIC_BASE_PA | GIC_OFFSET_GICC, \
+        CFG_GIC_BASE_PA | GIC_OFFSET_GICVI, SZ_8K, LPAED_STAGE2_MEMATTR_DM }, \
+{ 0, 0, 0, 0, 0 } \
+}
+
+#define CFG_GUEST1_DEVICE_MEMORY \
+{ \
+{ "uart", 0x1C090000, 0x1C0B0000, SZ_4K, LPAED_STAGE2_MEMATTR_DM }, \
+{ "sp804", 0x1C110000, 0x1C120000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },\
+{ "gicc", 0x2C000000 | GIC_OFFSET_GICC, \
+   CFG_GIC_BASE_PA | GIC_OFFSET_GICVI, SZ_8K, LPAED_STAGE2_MEMATTR_DM },\
+{0, 0, 0, 0, 0} \
+}
+

--- a/platform-device/cortex_a15x2_rtsm/patch/rtsm/model.lds.S
+++ b/platform-device/cortex_a15x2_rtsm/patch/rtsm/model.lds.S
@@ -1,0 +1,105 @@
+/*
+ * model.lds.S - simple linker script for stand-alone Linux booting
+ *
+ * Copyright (C) 2011 ARM Limited. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE.txt file.
+ */
+
+OUTPUT_FORMAT("elf32-littlearm")
+OUTPUT_ARCH(arm)
+TARGET(binary)
+ENTRY(start)
+
+#include "config/memmap.cfg"
+
+INPUT(./guestimages/guest0.bin)
+INPUT(./guestimages/guest1.bin)
+
+MON_SIZE    = 0x0F000000;
+MON_STACK   = CFG_MEMMAP_MON_OFFSET + MON_SIZE;
+MON_STACK_SIZE  = 0x00c00000;
+
+SEC_STACKTOP = MON_STACK + MON_STACK_SIZE;
+SEC_STACK_SIZE  = 0x00400000;
+
+/* NS.SVC mode code space
+ * - simon
+ */
+GUEST_SIZE_MAX  = 0x0F000000;
+GUEST_STACK     = CFG_MEMMAP_GUEST_OFFSET + GUEST_SIZE_MAX;
+
+GUEST2_STACK    = CFG_MEMMAP_GUEST2_OFFSET + GUEST_SIZE_MAX;
+
+SECTIONS
+{
+ . = CFG_MEMMAP_PHYS_START;
+ . = CFG_MEMMAP_PHYS_START + 0x8000 - 0x40;
+ . = CFG_MEMMAP_PHYS_START + 0x00d00000;
+
+ fs_start = .;
+ fs_end = .;
+
+/* Guest 1 */
+ . = CFG_MEMMAP_GUEST_OFFSET;
+  guest_bin_start = .;
+  .guest : { ./guestimages/guest0.bin}
+  guest_bin_end = .;
+
+ . = GUEST_STACK;
+ guest_stacktop = .;
+ . = GUEST_STACK + 0x01000000;
+ guest_stacklimit = .;
+
+/* Guest 2 */
+ . = CFG_MEMMAP_GUEST2_OFFSET;
+  guest2_bin_start = .;
+ .guest2 : { ./guestimages/guest1.bin }
+  guest2_bin_end = .;
+
+ . = GUEST2_STACK;
+ guest2_stacktop = .;
+ . = GUEST2_STACK + 0x01000000;
+ guest2_stacklimit = .;
+
+ . = CFG_MEMMAP_MON_OFFSET;
+ /* Put most of the actual boot loader code up in high memory
+  * where it won't get overwritten by kernel, initrd or atags.
+  */
+ .text : {
+    *(.text);
+    __vdev_module_high_start = .;
+    *(.vdev_module0.init);
+    __vdev_module_high_end = .;
+    *(.vdev_module1.init);
+    __vdev_module_middle_end = .;
+    *(.vdev_module2.init);
+    __vdev_module_low_end = .;
+ }
+
+ .= ALIGN(4);
+ .rodata : {
+    *(.rodata)
+ }
+ .= ALIGN(4);
+ .data : {
+    *(.data)
+ }
+ .= ALIGN(4);
+ begin_bss = .;
+ .bss : {
+    *(.bss)
+ }
+ end_bss = .;
+
+ . = MON_STACK;
+ mon_stacktop = .;
+ . = MON_STACK + MON_STACK_SIZE;
+ mon_stacklimit = .;
+
+ . = SEC_STACKTOP;
+ sec_stacktop = .;
+ . = SEC_STACKTOP + SEC_STACK_SIZE;
+ sec_stacklimit = .;
+}

--- a/platform-device/cortex_a15x2_rtsm/patch/vexpress/cfg_platform.h
+++ b/platform-device/cortex_a15x2_rtsm/patch/vexpress/cfg_platform.h
@@ -1,0 +1,86 @@
+/*
+ *  BOARD param
+ */
+#define CFG_BOARD_RTSM_VE_CA15
+#define CFG_GENERIC_CA15
+#define CFG_CNTFRQ          1000000000
+#define CFG_UART2         0x1C0B0000
+#define CFG_UART1         0x1C0A0000
+#define CFG_UART0         0x1C090000
+/*
+ *  SOC param
+ */
+#define CFG_GIC_BASE_PA   0x2c000000
+
+#define CFG_MACHINE_NUMBER 2272
+
+#define SZ_1                0x00000001
+#define SZ_2                0x00000002
+#define SZ_4                0x00000004
+#define SZ_8                0x00000008
+#define SZ_16               0x00000010
+#define SZ_32               0x00000020
+#define SZ_64               0x00000040
+#define SZ_128              0x00000080
+#define SZ_256              0x00000100
+#define SZ_512              0x00000200
+
+#define SZ_1K               0x00000400
+#define SZ_2K               0x00000800
+#define SZ_4K               0x00001000
+#define SZ_8K               0x00002000
+#define SZ_16K              0x00004000
+#define SZ_32K              0x00008000
+#define SZ_64K              0x00010000
+#define SZ_128K             0x00020000
+#define SZ_256K             0x00040000
+#define SZ_512K             0x00080000
+
+#define SZ_1M               0x00100000
+#define SZ_2M               0x00200000
+#define SZ_4M               0x00400000
+#define SZ_8M               0x00800000
+#define SZ_16M              0x01000000
+#define SZ_32M              0x02000000
+#define SZ_64M              0x04000000
+#define SZ_128M             0x08000000
+#define SZ_256M             0x10000000
+#define SZ_512M             0x20000000
+
+#define SZ_1G               0x40000000
+#define SZ_2G               0x80000000
+/**
+ * label, ipa, pa, size, attr
+ */
+#define CFG_GUEST0_DEVICE_MEMORY \
+{ \
+{ "sysreg", 0x1C010000, 0x1C010000, SZ_4K, LPAED_STAGE2_MEMATTR_DM }, \
+{ "sysctl", 0x1C020000, 0x1C020000, SZ_4K, LPAED_STAGE2_MEMATTR_DM }, \
+{ "aaci", 0x1C040000, 0x1C040000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },   \
+{ "mmci", 0x1C050000, 0x1C050000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },   \
+{ "kmi", 0x1C060000, 0x1C060000,  SZ_4K, LPAED_STAGE2_MEMATTR_DM },   \
+{ "kmi2", 0x1C070000, 0x1C070000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },   \
+{ "v2m_serial0", 0x1C090000, 0x1C0A0000, SZ_4K, LPAED_STAGE2_MEMATTR_DM }, \
+{ "v2m_serial1", 0x1C0A0000, 0x1C090000, SZ_4K, LPAED_STAGE2_MEMATTR_DM }, \
+{ "v2m_serial2", 0x1C0B0000, 0x1C0B0000, SZ_4K, LPAED_STAGE2_MEMATTR_DM }, \
+{ "v2m_serial3", 0x1C0C0000, 0x1C0C0000, SZ_4K, LPAED_STAGE2_MEMATTR_DM }, \
+{ "wdt", 0x1C0F0000, 0x1C0F0000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },         \
+{ "v2m_timer01(sp804)", 0x1C110000, 0x1C110000, SZ_4K, \
+        LPAED_STAGE2_MEMATTR_DM }, \
+{ "v2m_timer23", 0x1C120000, 0x1C120000, SZ_4K, LPAED_STAGE2_MEMATTR_DM }, \
+{ "rtc", 0x1C170000, 0x1C170000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },         \
+{ "clcd", 0x1C1F0000, 0x1C1F0000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },        \
+{ "gicc", CFG_GIC_BASE_PA | GIC_OFFSET_GICC, \
+        CFG_GIC_BASE_PA | GIC_OFFSET_GICVI, SZ_8K, LPAED_STAGE2_MEMATTR_DM }, \
+{ 0, 0, 0, 0, 0 } \
+}
+
+#define CFG_GUEST1_DEVICE_MEMORY \
+{ \
+{ "uart", 0x1C090000, 0x1C0B0000, SZ_4K, LPAED_STAGE2_MEMATTR_DM }, \
+{ "sp804", 0x1C110000, 0x1C120000, SZ_4K, LPAED_STAGE2_MEMATTR_DM },\
+{ "gicc", 0x2C000000 | GIC_OFFSET_GICC, \
+   CFG_GIC_BASE_PA | GIC_OFFSET_GICVI, SZ_8K, LPAED_STAGE2_MEMATTR_DM },\
+{0, 0, 0, 0, 0} \
+}
+

--- a/platform-device/cortex_a15x2_rtsm/patch/vexpress/model.lds.S
+++ b/platform-device/cortex_a15x2_rtsm/patch/vexpress/model.lds.S
@@ -1,0 +1,100 @@
+/*
+ * model.lds.S - simple linker script for stand-alone Linux booting
+ *
+ * Copyright (C) 2011 ARM Limited. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE.txt file.
+ */
+
+OUTPUT_FORMAT("elf32-littlearm")
+OUTPUT_ARCH(arm)
+TARGET(binary)
+ENTRY(start)
+
+#include "config/memmap.cfg"
+
+MON_SIZE    = 0x0F000000;
+MON_STACK   = CFG_MEMMAP_MON_OFFSET + MON_SIZE;
+MON_STACK_SIZE  = 0x00c00000;
+
+SEC_STACKTOP = MON_STACK + MON_STACK_SIZE;
+SEC_STACK_SIZE  = 0x00400000;
+
+/* NS.SVC mode code space
+ * - simon
+ */
+GUEST_SIZE_MAX  = 0x0F000000;
+GUEST_STACK     = CFG_MEMMAP_GUEST_OFFSET + GUEST_SIZE_MAX;
+
+GUEST2_STACK    = CFG_MEMMAP_GUEST2_OFFSET + GUEST_SIZE_MAX;
+
+SECTIONS
+{
+ . = CFG_MEMMAP_PHYS_START;
+ . = CFG_MEMMAP_PHYS_START + 0x8000 - 0x40;
+ . = CFG_MEMMAP_PHYS_START + 0x00d00000;
+
+ fs_start = .;
+ fs_end = .;
+
+/* Guest 1 */
+ . = CFG_MEMMAP_GUEST_OFFSET;
+  guest_bin_start = .;
+  guest_bin_end = .;
+
+ . = GUEST_STACK;
+ guest_stacktop = .;
+ . = GUEST_STACK + 0x01000000;
+ guest_stacklimit = .;
+
+/* Guest 2 */
+ . = CFG_MEMMAP_GUEST2_OFFSET;
+  guest2_bin_start = .;
+  guest2_bin_end = .;
+
+ . = GUEST2_STACK;
+ guest2_stacktop = .;
+ . = GUEST2_STACK + 0x01000000;
+ guest2_stacklimit = .;
+
+ . = CFG_MEMMAP_MON_OFFSET;
+ /* Put most of the actual boot loader code up in high memory
+  * where it won't get overwritten by kernel, initrd or atags.
+  */
+ .text : {
+    *(.text);
+    __vdev_module_high_start = .;
+    *(.vdev_module0.init);
+    __vdev_module_high_end = .;
+    *(.vdev_module1.init);
+    __vdev_module_middle_end = .;
+    *(.vdev_module2.init);
+    __vdev_module_low_end = .;
+ }
+
+ .= ALIGN(4);
+ .rodata : {
+    *(.rodata)
+ }
+ .= ALIGN(4);
+ .data : {
+    *(.data)
+ }
+ .= ALIGN(4);
+ begin_bss = .;
+ .bss : {
+    *(.bss)
+ }
+ end_bss = .;
+
+ . = MON_STACK;
+ mon_stacktop = .;
+ . = MON_STACK + MON_STACK_SIZE;
+ mon_stacklimit = .;
+
+ . = SEC_STACKTOP;
+ sec_stacktop = .;
+ . = SEC_STACKTOP + SEC_STACK_SIZE;
+ sec_stacklimit = .;
+}

--- a/platform-device/cortex_a15x2_rtsm/patch/vexpress/vexpress_ca15_tc2_bm.h
+++ b/platform-device/cortex_a15x2_rtsm/patch/vexpress/vexpress_ca15_tc2_bm.h
@@ -1,0 +1,25 @@
+/*
+ * (C) Copyright 2013 Linaro
+ * Andre Przywara, <andre.przywara@linaro.org>
+ *
+ * Configuration for Versatile Express. Parts were derived from other ARM
+ *   configurations.
+ *
+ * SPDX-License-Identifier:	GPL-2.0+
+ */
+
+#ifndef __VEXPRESS_CA15X2_TC2_h
+#define __VEXPRESS_CA15X2_TC2_h
+
+#define CONFIG_VEXPRESS_EXTENDED_MEMORY_MAP
+#include "vexpress_common.h"
+#define CONFIG_BOOTP_VCI_STRING     "U-boot.armv7.vexpress_ca15x2_tc2"
+
+#define CONFIG_SYSFLAGS_ADDR	0x1c010030
+#define CONFIG_SMP_PEN_ADDR	CONFIG_SYSFLAGS_ADDR
+
+#define CONFIG_ARMV7_VIRT
+
+#define CONFIG_BOOTCOMMAND "cp 0xc000000 0xf0000000 0xbf7c;cp 0xc100000 0xa0000000 0x101a44;cp 0x3000000 0xd0000000 0x101a44;go 0xf000004c"
+
+#endif

--- a/platform-device/cortex_a15x2_rtsm/patch/vexpress/vexpress_ca15_tc2_linux.h
+++ b/platform-device/cortex_a15x2_rtsm/patch/vexpress/vexpress_ca15_tc2_linux.h
@@ -1,0 +1,25 @@
+/*
+ * (C) Copyright 2013 Linaro
+ * Andre Przywara, <andre.przywara@linaro.org>
+ *
+ * Configuration for Versatile Express. Parts were derived from other ARM
+ *   configurations.
+ *
+ * SPDX-License-Identifier:	GPL-2.0+
+ */
+
+#ifndef __VEXPRESS_CA15X2_TC2_h
+#define __VEXPRESS_CA15X2_TC2_h
+
+#define CONFIG_VEXPRESS_EXTENDED_MEMORY_MAP
+#include "vexpress_common.h"
+#define CONFIG_BOOTP_VCI_STRING     "U-boot.armv7.vexpress_ca15x2_tc2"
+
+#define CONFIG_SYSFLAGS_ADDR	0x1c010030
+#define CONFIG_SMP_PEN_ADDR	CONFIG_SYSFLAGS_ADDR
+
+#define CONFIG_ARMV7_VIRT
+
+#define CONFIG_BOOTCOMMAND "cp 0xc000000 0xf0000000 0xbf7c;cp 0xc100000 0xa0000000 0x6285FC;cp 0x3000000 0xd0000000 0x101a44;go 0xf000004c"
+
+#endif


### PR DESCRIPTION
To support vexpress, modifies source codes
- Fix uart code to support vexpress
- Configure and separate build scripts
- Add board configuration files, memory linker scripts and u-boot booting commands
- Modify Makefiles
- Add manual to support vexpress
